### PR TITLE
Marked shift title and location as HTML safe

### DIFF
--- a/scheduler/templates/shift_cancellation_notification.html
+++ b/scheduler/templates/shift_cancellation_notification.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% blocktrans with shift_title=shift.task.name.strip location=shift.facility.name.strip from_date=shift.starting_time.date|date from_time=shift.starting_time.time to_time=shift.ending_time.time %}
+{% load i18n %}{% blocktrans with shift_title=shift.task.name.strip|safe location=shift.facility.name.strip|safe from_date=shift.starting_time.date|date from_time=shift.starting_time.time to_time=shift.ending_time.time %}
 Hallo,
 
 leider musste auf Wunsch der Zuständigen die folgende Schicht abgesagt werden:

--- a/scheduler/templates/shift_modification_notification.html
+++ b/scheduler/templates/shift_modification_notification.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% blocktrans with shift_title=shift.task.name.strip location=shift.facility.name.strip from_date=shift.starting_time.date|date from_time=shift.starting_time.time to_time=shift.ending_time.time old_from_date=old.starting_time.date|date old_from_time=old.starting_time.time old_to_time=old.ending_time.time %}
+{% load i18n %}{% blocktrans with shift_title=shift.task.name.strip|safe location=shift.facility.name.strip|safe from_date=shift.starting_time.date|date from_time=shift.starting_time.time to_time=shift.ending_time.time old_from_date=old.starting_time.date|date old_from_time=old.starting_time.time old_to_time=old.ending_time.time %}
 Hallo,
 
 wir mussten die folgende Schicht zeitlich anpassen:


### PR DESCRIPTION
In notification emails shift title and facility name were HTML escaped.
This lead to HTML entities in plain text mails for certain special
chacters, like '&' (ampersand).