### PR TITLE
Add comfort features to "Apply schedule template" views

### DIFF
--- a/scheduletemplates/admin.py
+++ b/scheduletemplates/admin.py
@@ -109,9 +109,7 @@ class ScheduleTemplateAdmin(MembershipFilteredAdmin):
 
     def response_change(self, request, obj):
         if "_save_and_apply" in request.POST:
-            redirect_url = reverse('admin:apply_schedule_template',
-                                   args=(obj._get_pk_val(),))
-            return HttpResponseRedirect(redirect_url)
+            return redirect('admin:apply_schedule_template', obj._get_pk_val())
         return super(ScheduleTemplateAdmin, self).response_change(request, obj)
 
     def apply_schedule_template(self, request, pk):
@@ -217,7 +215,7 @@ class ScheduleTemplateAdmin(MembershipFilteredAdmin):
                     context)
 
             # Phase 3: Create shifts
-            elif request.POST.get('confirm'):
+            elif request.POST.get('confirm') or request.POST.get('confirm_and_repeat'):
                 for template in selected_shift_templates:
                     starting_time = datetime.combine(apply_date,
                                                      template.starting_time)
@@ -235,15 +233,21 @@ class ScheduleTemplateAdmin(MembershipFilteredAdmin):
                     len(id_list)).format(
                     num_shifts=len(id_list),
                     date=localize(apply_date)))
-                return redirect(
-                    'admin:scheduletemplates_scheduletemplate_change', pk)
+                if request.POST.get('confirm'):
+                    return redirect(
+                        'admin:scheduletemplates_scheduletemplate_change', pk)
+                else:
+                    return redirect('admin:apply_schedule_template', pk)
             else:
                 messages.error(request, _(
                     u'Something didn\'t work. Sorry about that.').format(
                     len(id_list),
                     localize(apply_date)))
-                return redirect(
-                    'admin:scheduletemplates_scheduletemplate_change', pk)
+                if request.POST.get('confirm'):
+                    return redirect(
+                        'admin:scheduletemplates_scheduletemplate_change', pk)
+                else:
+                    return redirect('admin:apply_schedule_template', pk)
 
     def get_urls(self):
         urls = super(ScheduleTemplateAdmin, self).get_urls()

--- a/scheduletemplates/templates/admin/scheduletemplates/apply_template.html
+++ b/scheduletemplates/templates/admin/scheduletemplates/apply_template.html
@@ -62,6 +62,8 @@
             <div>
                 {{ apply_form.apply_for_date }}
 
+                <input type="submit" value="{% trans "Continue" %}"
+                       class="default" name="preview" style="float: initial;">
             </div>
 
             <h3>{% trans "Select shift templates" %}</h3>
@@ -117,7 +119,7 @@
                 </table>
             </div>
             <div class="submit-row">
-                <input type="submit" value="{% trans "Preview shifts to add" %}"
+                <input type="submit" value="{% trans "Continue" %}"
                        class="default" name="preview">
             </div>
     </div>

--- a/scheduletemplates/templates/admin/scheduletemplates/apply_template_confirm.html
+++ b/scheduletemplates/templates/admin/scheduletemplates/apply_template_confirm.html
@@ -118,8 +118,10 @@
         </table>
         </p>
         <div class="submit-row">
-            <input type="submit" value="{% trans "Apply selected shifts" %}"
+            <input type="submit" value="{% trans "Apply" %}"
                    class="default" name="confirm">
+            <input type="submit" value="{% trans "Apply and select new date" %}"
+                   class="default" name="confirm_and_repeat">
         </div>
     </form>
 {% endblock %}


### PR DESCRIPTION
As per user request:

* put an additional "Continue" button next to the date input widget in the apply view
* added an button "Apply and select new date" to confirm and go back to the previous view to save time when applying a template to multiple dates in a row