### PR TITLE
Do not throw away user entered data during registration

### DIFF
--- a/templates/registration/registration_form.html
+++ b/templates/registration/registration_form.html
@@ -7,6 +7,7 @@
     <h1 class="align-right">volunteer-planner.org</h1>
     <h2 class="align-right">{% trans "Registration" %}</h2>
 </div>
+
 <div class="col-md-3 border-left form-container">
     {{ form.non_field_errors }}
 
@@ -15,18 +16,18 @@
             {% for email_error in form.email.errors %}
                 <div class="alert alert-danger" role="alert">{{ email_error }}</div>
             {% endfor %}
-            <input type="email" class="form-control" placeholder="{% trans "Email" %}" name="email">
+            <input type="email" class="form-control" placeholder="{% trans "Email" %}" name="email" value="{{ form.cleaned_data.email }}">
         </div>
         <div class="form-group {%  if form.username.errors %} has-error{% endif %}">
             <label {%  if form.username.errors %} style="color:red"{% endif %} for="Username">{%  if form.username.errors %} {% trans "Username already exists. Please choose a different username." %} {% endif %}</label>
-            <input class="form-control " id="Username" placeholder="{% trans "Username" %}" name="username">
+            <input class="form-control " id="Username" placeholder="{% trans "Username" %}" name="username" value="{{ form.cleaned_data.username }}">
         <p class="help-block">{% trans "Don't use spaces or special characters" %}</p>
         </div>
           <div class="form-group">
-            <input type="password" class="form-control" placeholder="{% trans "Password" %}" name="password1">
+            <input type="password" class="form-control" placeholder="{% trans "Password" %}" name="password1" value="{{ form.cleaned_data.password1 }}">
           </div>
           <div class="form-group">
-            <input type="password" class="form-control" placeholder="{% trans "Repeat password" %}" name="password2">
+            <input type="password" class="form-control" placeholder="{% trans "Repeat password" %}" name="password2" value="{{ form.cleaned_data.password2 }}">
           </div>
         <button type="submit" class="btn btn-primary align-left">{% trans "Sign-up" %}</button>
     </form>


### PR DESCRIPTION
Something noticed when registering just now is that any error during
registration throws away all the already entered data. The stock
django form rendering would maintain it but since the template is
fully hand rolled it was missing a value field that lifts any existing
data from cleaned_data.

It is fairly frustrating for new users to have te re-enter e-mail
addresses and passwords etc.