### PR TITLE
add 404 and 500 templates (#259)

### DIFF
--- a/non_logged_in_area/templates/404.html
+++ b/non_logged_in_area/templates/404.html
@@ -1,0 +1,13 @@
+{% extends 'base_non_logged_in.html' %}
+{% load i18n %}
+
+{% block title %} Volunteer Planner - 404{% endblock %}
+{% block content %}
+    <div class="container">
+        <div class="row">
+		<h2>{% trans "Page not found" %}</h2>
+		<pre>{{ request_path }}</pre>
+		<p>{% trans "We're sorry, but the requested page could not be found." %}</p>
+        </div>
+    </div>
+{% endblock %}

--- a/non_logged_in_area/templates/500.html
+++ b/non_logged_in_area/templates/500.html
@@ -1,0 +1,17 @@
+{% extends "base_non_logged_in.html" %}
+{% load i18n %}
+
+{% block title %} Volunteer Planner - {% trans "Server error" %}{% endblock %}
+{% block content %}
+    <div class="container">
+        <div class="row">
+		<h1>{% trans "Server Error <em>(500)</em>" %}</h1>
+		<p>
+		{% blocktrans trimmed %}
+			There's been an error. It's been reported to the site administrators via 
+			email and should be fixed shortly. Thanks for your patience.
+		{% endblocktrans %}
+		</p>
+        </div>
+    </div>
+{% endblock %}

--- a/non_logged_in_area/urls.py
+++ b/non_logged_in_area/urls.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from django.conf.urls import url
+from django.views.defaults import page_not_found, server_error
 
 from .views import HomeView
 
@@ -8,4 +9,6 @@ urlpatterns = [
     url(r'^shelters-need-help/$', HomeView.as_view(template_name="shelters_need_help.html"), name="shelter_info"),
     url(r'^faqs/$', HomeView.as_view(template_name="faqs.html"), name="faqs"),
     url(r'^privacy-policy/$', HomeView.as_view(template_name="privacy_policy.html"), name="privacy"),
+    url(r'^404/$', page_not_found),
+    url(r'^500/$', server_error),
 ]


### PR DESCRIPTION
The translation strings come from django, so nothing was added
to-be-translated. (However, I am not sure if the 500 page is lying or not
-- will someone be sent an email?)

It might make sense to include another pair, for logged-in users, but it
does not feel too necessary imho.

I couldn't get these to work with `DEBUG=True`, so I explicitly added
URL patterns to view them (see e.g. [here](http://spapas.github.io/2015/04/29/django-show-404-page/)):

- [http://localhost:8000/404](http://localhost:8000/404)
- [http://localhost:8000/500](http://localhost:8000/500)

HEADSUP for deployment: this should be tested with `DEBUG=False` before
deployment.

(Dear GitHub, this is related to #259)