### PR TITLE
Show shifts that happen on the shift day (#286)

### DIFF
--- a/scheduler/managers.py
+++ b/scheduler/managers.py
@@ -11,7 +11,7 @@ from places import models as place_models
 class ShiftQuerySet(models.QuerySet):
     def on_shiftdate(self, shiftdate):
         next_day = datetime.combine(shiftdate + timedelta(days=1), time.min)
-        return self.filter(starting_time__gte=shiftdate,
+        return self.filter(ending_time__gte=shiftdate,
                            starting_time__lt=next_day)
 
     def at_place(self, place):


### PR DESCRIPTION
If a shift ends at 2015-11-24 02:00, it should be shown on
`shifts/2015/11/24`. The old query,

    shiftday <= starting_time < shiftday+1

excluded those shifts. The new query doesn't:

    shiftday <= ending_time AND starting_time < shiftday+1