### PR TITLE
registration form bugfixes

### DIFF
--- a/templates/registration/registration_form.html
+++ b/templates/registration/registration_form.html
@@ -12,22 +12,23 @@
     {{ form.non_field_errors }}
 
     <form method='post' action=''>{% csrf_token %}
-        <div class="form-group ">
+        <div class="form-group {% if form.email.errors %}has-error{% endif %}">
             {% for email_error in form.email.errors %}
                 <div class="alert alert-danger" role="alert">{{ email_error }}</div>
             {% endfor %}
             <input type="email" class="form-control" placeholder="{% trans "Email" %}" name="email" value="{{ form.cleaned_data.email }}">
         </div>
-        <div class="form-group {%  if form.username.errors %} has-error{% endif %}">
-            <label {%  if form.username.errors %} style="color:red"{% endif %} for="Username">{%  if form.username.errors %} {% trans "Username already exists. Please choose a different username." %} {% endif %}</label>
-            <input class="form-control " id="Username" placeholder="{% trans "Username" %}" name="username" value="{{ form.cleaned_data.username }}">
+        <div class="form-group {% if form.username.errors %}has-error{% endif %}">
+            <label {% if form.username.errors %}style="color:red"{% endif %} for="Username">{% if form.username.errors %}{% trans "Username already exists. Please choose a different username." %}{% endif %}</label>
+            <input class="form-control" id="Username" placeholder="{% trans "Username" %}" name="username" value="{{ form.cleaned_data.username }}">
         <p class="help-block">{% trans "Don't use spaces or special characters" %}</p>
         </div>
           <div class="form-group">
             <input type="password" class="form-control" placeholder="{% trans "Password" %}" name="password1" value="{{ form.cleaned_data.password1 }}">
           </div>
-          <div class="form-group">
-            <input type="password" class="form-control" placeholder="{% trans "Repeat password" %}" name="password2" value="{{ form.cleaned_data.password2 }}">
+          <div class="form-group {% if form.password2.errors %}has-error{% endif %}">
+            <label {% if form.password2.errors %}style="color:red"{% endif %} for="password2">{% if form.password2.errors %}{% trans "The two password fields didn't match." %}{% endif %}</label>
+            <input type="password" class="form-control" placeholder="{% trans "Repeat password" %}" id="password2" name="password2" value="{{ form.cleaned_data.password2 }}">
           </div>
         <button type="submit" class="btn btn-primary align-left">{% trans "Sign-up" %}</button>
     </form>

--- a/volunteer_planner/urls.py
+++ b/volunteer_planner/urls.py
@@ -3,10 +3,11 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import TemplateView
 from content.views import translated_flatpage
+from registration.backends.default.views import RegistrationView
+from registration.forms import RegistrationFormUniqueEmail
 
 urlpatterns = [
-    # Examples:
-
+    url(r'^auth/register/$', RegistrationView.as_view(form_class=RegistrationFormUniqueEmail), name='registration_register'),
     url(r'^auth/', include('registration.backends.default.urls')),
     url(r'^account/', include('accounts.urls')),
     url(r'^faq/', TemplateView.as_view(template_name='faq.html'), name="faq"),


### PR DESCRIPTION
- display password mismatch (#292): apparently, mismatching passwords
  are not (anymore?) non_field_errors, but errors of the second field
- switch registration form class to check for email uniqueness (#161)

![screenshot](https://cloud.githubusercontent.com/assets/870638/11370061/3d2f080e-92c2-11e5-9f11-3333885f8a2f.png)

I didn't touch the way email address errors are displayed, since I have no clue if there could be more than one of them at a time.

Note that the current logic might hide some bugs: in both cases, username and password(s), if _any error_ occurs, a _fixed_ error message (relating to one specific kind of error) is displayed. This might be confusing if another kind of error is possible. I have no idea if that's the case, though.