### PR TITLE
First step to better shifts over midnight 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - CHANGELOG is now Markdown
+- additional information: If shifts span over midnight there is need of additional information to differentiate between shifts that start today and shifts that started yesterday. In these cases the date is shown in the field where the time is shown. 
 
 ### Fixed
 - some PEP8 fixes of the source code

--- a/scheduler/templates/helpdesk_single.html
+++ b/scheduler/templates/helpdesk_single.html
@@ -280,12 +280,32 @@
                                                 <a href="#{{ shift.id }}"
                                                    class="fa fa-link"></a>
                                             </td>
-                                            <td>
-                                                {{ shift.starting_time|date:"H:i" }}
-                                            </td>
-                                            <td>
-                                                {{ shift.ending_time|date:"H:i" }}
-                                            </td>
+
+                                            {% comment "" %}
+                                            "The following if/else is necessary for shifts spanning over midnight. Otherwise it is not
+                                                possible to differentiate between shifts starting today and shifts
+                                                starting yesterday:"
+                                            {% endcomment %}
+
+                                            {% if shift.starting_time|date == shift.ending_time|date %}
+                                                <td>
+                                                    {{ shift.starting_time|date:"H:i"}}
+                                                </td>
+                                                <td>
+                                                    {{ shift.ending_time|date:"H:i" }}
+                                                </td>
+                                            {% else %}
+                                                <td>
+                                                    {{ shift.starting_time|date}}
+                                                    {{ shift.starting_time|date:"H:i"}}
+                                                </td>
+                                                <td>
+                                                    {{ shift.ending_time|date}}
+                                                    {{ shift.ending_time|date:"H:i" }}
+                                                </td>
+                                            {% endif %}
+
+
                                             <td>
                                                 {{ shift.slots }}
                                                 {% if shift.members_only %}


### PR DESCRIPTION
- changed helpdesk_single: If shifts over midnight there is need of additional information to differentiate between shifts that start today and shifts started yesterday. In these cases they date is shown too in the field where the time is shown.

![shifts_spanning_v2](https://cloud.githubusercontent.com/assets/582775/13380965/8340b8d2-de4f-11e5-8c8c-87cb651ed40b.jpg)


