### PR TITLE
Fix main column alignment on helpdesk page

### DIFF
--- a/scheduler/templates/helpdesk.html
+++ b/scheduler/templates/helpdesk.html
@@ -35,16 +35,15 @@
 {% load osm_links i18n %}
 {% block content %}
 
-        <div ng-cloak class="area-filter row" ng-controller="ShiftWidgetCtrl">
+        <div ng-cloak ng-controller="ShiftWidgetCtrl">
             <h2>{% trans "You can help in the following facilities" %}</h2>
             {% verbatim %}
                 <hr>
-                <div class="col-md12">
+                <div>
                     {% endverbatim %}<span>{% trans "filter" %}:</span>{% verbatim %}
                     <label class="area-filter" ng-repeat="area in areas">
                         <input type="checkbox" value="{{ area.name }}"
 
-                            class=""
                             ng-click="toggleArea(area.slug)"
                             ng-class="{ 'fddf': selectedAreas.indexOf(area.slug) > -1 }"
                             >{{ area.name }}

--- a/scheduler/templates/helpdesk_single.html
+++ b/scheduler/templates/helpdesk_single.html
@@ -163,7 +163,7 @@
 
     {% include "partials/alert_messages.html" %}
 
-    <div class="row">
+    <div>
         <h2>
             {{ facility.name }}
         </h2>
@@ -205,7 +205,7 @@
                 {% for shift_by_workplace in shifts_by_workplace %}
                     {% with shift_by_workplace.grouper as workplace %}
 
-                        <div class="row">
+                        <div>
                             <h3 id="task-{{ task.id }}-{{ workplace.id }}">
                                 {% if workplace %}
                                     {{ task.name }} -


### PR DESCRIPTION
Small improvement to fix the misalignment of elements in the main content column on https://volunteer-planner.org/helpdesk/ in desktop & mobile views:

![bildschirmfoto 2016-03-02 um 23 57 49](https://cloud.githubusercontent.com/assets/34942/13479742/6aea9208-e0d9-11e5-8943-12475be9dfba.png)

![bildschirmfoto 2016-03-03 um 00 00 46](https://cloud.githubusercontent.com/assets/34942/13479752/7a4998ca-e0d9-11e5-8ab4-ea214a30da3e.png)

Expected outcome:

![bildschirmfoto 2016-03-03 um 00 50 43](https://cloud.githubusercontent.com/assets/34942/13479832/0391c800-e0da-11e5-8bf1-2a6252d4868e.png)

![bildschirmfoto 2016-03-03 um 00 49 41](https://cloud.githubusercontent.com/assets/34942/13479839/0c85e05e-e0da-11e5-85ca-2443926aa0a1.png)

