### PR TITLE
Reduce number of SQL queries

### DIFF
--- a/news/managers.py
+++ b/news/managers.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import itertools
 import logging
 

--- a/news/managers.py
+++ b/news/managers.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+import itertools
+import logging
+
+from django.db import models
+
+log = logging.getLogger(__name__)
+
+
+class NewsEntryQuerySet(models.QuerySet):
+    """ Custom QuerySet for NewsEntry.
+        Defines auxiliary methods for optimizing fetching for and from large lists of affected facilities.
+    """
+    def for_facilities(self, facilities):
+        """ Updates the query set to filter for a given set of facilities.
+
+            :param facilities: array or list of facilities to filter for
+            :type facilities: organization.models.Facility
+
+            :return: the query set configured to filter only for given facilities
+        """
+        log.debug(u'Filtering for %d facilities', len(facilities))
+        return self.filter(facility__in=facilities)
+
+    def filter_by_facility(self, facility):
+        """ Filters this NewsEntry query set for a given facility.
+
+            :param facility: Facility to filter for
+            :type facility: organization.models.Facility
+
+            :return: Iterator containing only news entries for the given facility
+        """
+        log.debug(u'Filtering news entries %s for facility %s', self, facility.name)
+        return itertools.ifilter(lambda entry: entry.facility_id == facility.id, self)
+
+# NewsEntry manager created from query set that enables filtering for facilities
+NewsEntryManager = models.Manager.from_queryset(NewsEntryQuerySet)

--- a/news/models.py
+++ b/news/models.py
@@ -4,6 +4,8 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.template.defaultfilters import slugify
 
+import managers
+
 
 class NewsEntry(models.Model):
     """
@@ -34,6 +36,8 @@ class NewsEntry(models.Model):
                                      related_name='news_entries',
                                      null=True,
                                      blank=True)
+
+    facility_news = managers.NewsEntryManager()
 
     class Meta:
         verbose_name = _('news entry')

--- a/news/models.py
+++ b/news/models.py
@@ -37,7 +37,7 @@ class NewsEntry(models.Model):
                                      null=True,
                                      blank=True)
 
-    facility_news = managers.NewsEntryManager()
+    objects = managers.NewsEntryManager()
 
     class Meta:
         verbose_name = _('news entry')

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -55,9 +55,7 @@ class FacilityView(DetailView):
     def get_context_data(self, **kwargs):
         context = super(FacilityView, self).get_context_data(**kwargs)
         shifts = Shift.open_shifts.filter(facility=self.object)
-        news = NewsEntry.objects.for_facilities(
-            [facility for facility, tmp in (itertools.groupby(shifts, lambda s: s.facility))]
-        ).all()
+        news = NewsEntry.objects.for_facilities([self.object])
         context['object'] = self.object
         context['facility'] = get_facility_details(self.object, shifts, news)  # FIXME
 

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -55,7 +55,7 @@ class FacilityView(DetailView):
     def get_context_data(self, **kwargs):
         context = super(FacilityView, self).get_context_data(**kwargs)
         shifts = Shift.open_shifts.filter(facility=self.object)
-        news = NewsEntry.facility_news.for_facilities(
+        news = NewsEntry.objects.for_facilities(
             [facility for facility, tmp in (itertools.groupby(shifts, lambda s: s.facility))]
         ).all()
         context['object'] = self.object

--- a/scheduler/managers.py
+++ b/scheduler/managers.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 import itertools
 

--- a/scheduler/managers.py
+++ b/scheduler/managers.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+import itertools
+
 from datetime import timedelta, datetime, time
 
 from django.db import models
@@ -62,7 +64,7 @@ ShiftManager = models.Manager.from_queryset(ShiftQuerySet)
 
 
 class OpenShiftManager(ShiftManager):
-    """ Manager for Shift. Overwrites get_queryset with a filter on QuerySet 
+    """ Manager for Shift. Overwrites get_queryset with a filter on QuerySet
         that holds all shifts that end now or in the future.
     """
     def get_queryset(self):

--- a/scheduler/views.py
+++ b/scheduler/views.py
@@ -63,14 +63,13 @@ class HelpDesk(LoginRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(HelpDesk, self).get_context_data(**kwargs)
         open_shifts = get_open_shifts()
-        shifts_by_facility = list(itertools.groupby(open_shifts,
-                                               lambda s: s.facility))
 
-        news = NewsEntry.objects.for_facilities([facility for facility, tmp in shifts_by_facility]).all()
+        news = NewsEntry.objects.for_facilities(
+            [facility for facility, tmp in itertools.groupby(open_shifts, lambda s: s.facility)]).all()
         facility_list = []
         used_places = set()
 
-        for facility, shifts_at_facility in shifts_by_facility:
+        for facility, shifts_at_facility in itertools.groupby(open_shifts, lambda s: s.facility):
             used_places.add(facility.place.area)
             facility_list.append(
                 get_facility_details(facility, shifts_at_facility, news))

--- a/scheduler/views.py
+++ b/scheduler/views.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 def get_open_shifts():
     shifts = Shift.open_shifts.all()
     shifts = shifts.select_related('facility',
+                                   'facility__organization',
                                    'facility__place',
                                    'facility__place__area',
                                    'facility__place__area__region',

--- a/scheduler/views.py
+++ b/scheduler/views.py
@@ -66,7 +66,7 @@ class HelpDesk(LoginRequiredMixin, TemplateView):
         shifts_by_facility = list(itertools.groupby(open_shifts,
                                                lambda s: s.facility))
 
-        news = NewsEntry.facility_news.for_facilities([facility for facility, tmp in shifts_by_facility]).all()
+        news = NewsEntry.objects.for_facilities([facility for facility, tmp in shifts_by_facility]).all()
         facility_list = []
         used_places = set()
 


### PR DESCRIPTION
Helpdesk start page creates many SQL queries to render facility links.
By optimizing QuerySet fetching open shifts this information is fetched
in one query, which reduces rendering time.
