### PR TITLE
Fix registration tests

### DIFF
--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-16 10:07+0100\n"
+"POT-Creation-Date: 2022-03-16 23:25+0100\n"
 "PO-Revision-Date: 2022-03-15 17:56+0000\n"
 "Last-Translator: Christoph Meißner\n"
 "Language-Team: Czech (http://www.transifex.com/coders4help/volunteer-planner/language/cs/)\n"
@@ -20,23 +20,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
-#: accounts/admin.py:20 accounts/admin.py:26
+#: accounts/admin.py:22 accounts/admin.py:28
 msgid "first name"
 msgstr "křestní jméno"
 
-#: accounts/admin.py:32
+#: accounts/admin.py:34 accounts/admin.py:61
 msgid "email"
 msgstr "e-mail"
 
-#: accounts/admin.py:39
-msgid "active"
-msgstr ""
-
-#: accounts/admin.py:45
+#: accounts/admin.py:67
 msgid "date joined"
 msgstr ""
 
-#: accounts/admin.py:51
+#: accounts/admin.py:73
 msgid "last login"
 msgstr ""
 
@@ -1661,7 +1657,6 @@ msgid "Activation email sent"
 msgstr "Aktivační e-mail odeslán"
 
 #: templates/registration/registration_complete.html:7
-#: tests/registration/test_registration.py:145
 msgid "An activation mail will be sent to you email address."
 msgstr "Aktivační e-mail vám bude zaslán na e-mailovou adresu."
 
@@ -1694,7 +1689,6 @@ msgid "Your username will be visible to other users. Don't use spaces or special
 msgstr "Vaše uživatelské jméno bude viditelné ostatním uživatelům. Nepoužívejte mezery nebo speciální znaky."
 
 #: templates/registration/registration_form.html:51
-#: tests/registration/test_registration.py:131
 msgid "The two password fields didn't match."
 msgstr "Dvě pole hesla si neodpovídají."
 
@@ -1713,18 +1707,6 @@ msgstr ""
 #: templates/registration/registration_form.html:76
 msgid "Sign-up"
 msgstr "Přihlásit se"
-
-#: tests/registration/test_registration.py:43
-msgid "This field is required."
-msgstr "Toto pole je povinné."
-
-#: tests/registration/test_registration.py:82
-msgid "Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr "Zadejte platné uživatelské jméno. Tato hodnota může obsahovat pouze písmena, čísla a znaky @/./+/-/_."
-
-#: tests/registration/test_registration.py:110
-msgid "A user with that username already exists."
-msgstr "Uživatel s tímto uživatelským jménem již existuje."
 
 #: volunteer_planner/settings/base.py:149
 msgid "English"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-16 10:07+0100\n"
+"POT-Creation-Date: 2022-03-16 23:25+0100\n"
 "PO-Revision-Date: 2016-11-21 18:24+0000\n"
 "Last-Translator: Sönke Klinger <klinger@biver.de>\n"
 "Language-Team: German (http://www.transifex.com/coders4help/volunteer-planner/language/de/)\n"
@@ -30,23 +30,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: accounts/admin.py:20 accounts/admin.py:26
+#: accounts/admin.py:22 accounts/admin.py:28
 msgid "first name"
 msgstr "Vorname"
 
-#: accounts/admin.py:32
+#: accounts/admin.py:34 accounts/admin.py:61
 msgid "email"
 msgstr "E-Mail"
 
-#: accounts/admin.py:39
-msgid "active"
-msgstr ""
-
-#: accounts/admin.py:45
+#: accounts/admin.py:67
 msgid "date joined"
 msgstr ""
 
-#: accounts/admin.py:51
+#: accounts/admin.py:73
 msgid "last login"
 msgstr "zuletzt eingeloggt"
 
@@ -1693,7 +1689,6 @@ msgid "Activation email sent"
 msgstr "Aktivierungsemail wurde versandt"
 
 #: templates/registration/registration_complete.html:7
-#: tests/registration/test_registration.py:145
 msgid "An activation mail will be sent to you email address."
 msgstr "Dir wird jetzt eine Aktivierungs-E-Mail zugesendet."
 
@@ -1726,7 +1721,6 @@ msgid "Your username will be visible to other users. Don't use spaces or special
 msgstr "Achtung! Der Benutzername ist sichtbar für andere Benutzer! Bitte keine Leerzeilen oder Sonderzeichen benutzen."
 
 #: templates/registration/registration_form.html:51
-#: tests/registration/test_registration.py:131
 msgid "The two password fields didn't match."
 msgstr "Die Passwörter stimmen nicht überein."
 
@@ -1745,18 +1739,6 @@ msgstr "Du musst diesen Haken setzen."
 #: templates/registration/registration_form.html:76
 msgid "Sign-up"
 msgstr "Eintragen"
-
-#: tests/registration/test_registration.py:43
-msgid "This field is required."
-msgstr "Dieses Feld ist zwingend erforderlich."
-
-#: tests/registration/test_registration.py:82
-msgid "Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr "Bitte einen gültigen Benutzernamen wählen (erlaubte Sonderzeichen: @/./+/-/_)."
-
-#: tests/registration/test_registration.py:110
-msgid "A user with that username already exists."
-msgstr "Es gibt bereits einen Benutzer mit diesem Benutzernamen."
 
 #: volunteer_planner/settings/base.py:149
 msgid "English"

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-16 10:07+0100\n"
+"POT-Creation-Date: 2022-03-16 23:25+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Greek (http://www.transifex.com/coders4help/volunteer-planner/language/el/)\n"
@@ -19,23 +19,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: accounts/admin.py:20 accounts/admin.py:26
+#: accounts/admin.py:22 accounts/admin.py:28
 msgid "first name"
 msgstr "Όνομα"
 
-#: accounts/admin.py:32
+#: accounts/admin.py:34 accounts/admin.py:61
 msgid "email"
 msgstr "Ηλεκτρονική διεύθυνση αλληλογραφίας (email)"
 
-#: accounts/admin.py:39
-msgid "active"
-msgstr ""
-
-#: accounts/admin.py:45
+#: accounts/admin.py:67
 msgid "date joined"
 msgstr ""
 
-#: accounts/admin.py:51
+#: accounts/admin.py:73
 msgid "last login"
 msgstr ""
 
@@ -1659,7 +1655,6 @@ msgid "Activation email sent"
 msgstr "Το email ενεργοποίησης εστάλη."
 
 #: templates/registration/registration_complete.html:7
-#: tests/registration/test_registration.py:145
 msgid "An activation mail will be sent to you email address."
 msgstr "Ένα email ενεργοποίησης θα σου σταλεί στην ηλεκτρονική σου διεύθυνση."
 
@@ -1692,7 +1687,6 @@ msgid "Your username will be visible to other users. Don't use spaces or special
 msgstr ""
 
 #: templates/registration/registration_form.html:51
-#: tests/registration/test_registration.py:131
 msgid "The two password fields didn't match."
 msgstr "Τα περιεχόμενο των δύο πεδίων κωδικού δεν είναι το ίδιο"
 
@@ -1711,18 +1705,6 @@ msgstr ""
 #: templates/registration/registration_form.html:76
 msgid "Sign-up"
 msgstr "Εγγραφή"
-
-#: tests/registration/test_registration.py:43
-msgid "This field is required."
-msgstr "Αυτό το πεδίο είναι υποχρεωτικό."
-
-#: tests/registration/test_registration.py:82
-msgid "Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr "Εισήγαγε ένα έγκυρο όνομα χρήστη. Αυτό μπορεί να περιλαμβάνει μόνο γράμματα, αριθμούς και τους χαρακτήρες @/./+/-/_ "
-
-#: tests/registration/test_registration.py:110
-msgid "A user with that username already exists."
-msgstr "Υπάρχει ήδη κάποιος χρήστης με αυτό το όνομα χρήστη. "
 
 #: volunteer_planner/settings/base.py:149
 msgid "English"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-16 10:07+0100\n"
+"POT-Creation-Date: 2022-03-16 23:25+0100\n"
 "PO-Revision-Date: 2015-10-04 21:53+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: English (http://www.transifex.com/coders4help/volunteer-planner/language/en/)\n"
@@ -16,23 +16,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: accounts/admin.py:20 accounts/admin.py:26
+#: accounts/admin.py:22 accounts/admin.py:28
 msgid "first name"
 msgstr ""
 
-#: accounts/admin.py:32
+#: accounts/admin.py:34 accounts/admin.py:61
 msgid "email"
 msgstr ""
 
-#: accounts/admin.py:39
-msgid "active"
-msgstr ""
-
-#: accounts/admin.py:45
+#: accounts/admin.py:67
 msgid "date joined"
 msgstr ""
 
-#: accounts/admin.py:51
+#: accounts/admin.py:73
 msgid "last login"
 msgstr ""
 
@@ -1590,7 +1586,6 @@ msgid "Activation email sent"
 msgstr ""
 
 #: templates/registration/registration_complete.html:7
-#: tests/registration/test_registration.py:145
 msgid "An activation mail will be sent to you email address."
 msgstr ""
 
@@ -1623,7 +1618,6 @@ msgid "Your username will be visible to other users. Don't use spaces or special
 msgstr ""
 
 #: templates/registration/registration_form.html:51
-#: tests/registration/test_registration.py:131
 msgid "The two password fields didn't match."
 msgstr ""
 
@@ -1641,18 +1635,6 @@ msgstr ""
 
 #: templates/registration/registration_form.html:76
 msgid "Sign-up"
-msgstr ""
-
-#: tests/registration/test_registration.py:43
-msgid "This field is required."
-msgstr ""
-
-#: tests/registration/test_registration.py:82
-msgid "Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr ""
-
-#: tests/registration/test_registration.py:110
-msgid "A user with that username already exists."
 msgstr ""
 
 #: volunteer_planner/settings/base.py:149

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-16 10:07+0100\n"
+"POT-Creation-Date: 2022-03-16 23:25+0100\n"
 "PO-Revision-Date: 2016-04-13 17:27+0000\n"
 "Last-Translator: Antonio Mireles <antonio@mirelesindependent.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/coders4help/volunteer-planner/language/es/)\n"
@@ -20,23 +20,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: accounts/admin.py:20 accounts/admin.py:26
+#: accounts/admin.py:22 accounts/admin.py:28
 msgid "first name"
 msgstr "nombre"
 
-#: accounts/admin.py:32
+#: accounts/admin.py:34 accounts/admin.py:61
 msgid "email"
 msgstr "correo electrónico"
 
-#: accounts/admin.py:39
-msgid "active"
-msgstr ""
-
-#: accounts/admin.py:45
+#: accounts/admin.py:67
 msgid "date joined"
 msgstr ""
 
-#: accounts/admin.py:51
+#: accounts/admin.py:73
 msgid "last login"
 msgstr ""
 
@@ -1656,7 +1652,6 @@ msgid "Activation email sent"
 msgstr "El correo electrónico de activación fue enviado"
 
 #: templates/registration/registration_complete.html:7
-#: tests/registration/test_registration.py:145
 msgid "An activation mail will be sent to you email address."
 msgstr "Un correo electrónico de activación será enviado a su dirección de correo electrónico. "
 
@@ -1689,7 +1684,6 @@ msgid "Your username will be visible to other users. Don't use spaces or special
 msgstr "Tu nombre de usuario va a ser visible a otros usuarios. No uses espacios o caracteres especiales."
 
 #: templates/registration/registration_form.html:51
-#: tests/registration/test_registration.py:131
 msgid "The two password fields didn't match."
 msgstr "Los dos campos para la contraseña no coinciden."
 
@@ -1708,18 +1702,6 @@ msgstr ""
 #: templates/registration/registration_form.html:76
 msgid "Sign-up"
 msgstr "Inscribirse"
-
-#: tests/registration/test_registration.py:43
-msgid "This field is required."
-msgstr "Este campo es obligatorio."
-
-#: tests/registration/test_registration.py:82
-msgid "Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr "Introduzca un nombre de usario válido. Sólo puede contener letras, numeros y los simbolos @/./+/-/_."
-
-#: tests/registration/test_registration.py:110
-msgid "A user with that username already exists."
-msgstr "Un usario con el mismo nombre de usario ya existe."
 
 #: volunteer_planner/settings/base.py:149
 msgid "English"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-16 10:07+0100\n"
+"POT-Creation-Date: 2022-03-16 23:25+0100\n"
 "PO-Revision-Date: 2016-12-08 20:50+0000\n"
 "Last-Translator: Dolfeus <dolfeus@sfr.fr>\n"
 "Language-Team: French (http://www.transifex.com/coders4help/volunteer-planner/language/fr/)\n"
@@ -23,23 +23,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: accounts/admin.py:20 accounts/admin.py:26
+#: accounts/admin.py:22 accounts/admin.py:28
 msgid "first name"
 msgstr "Nom"
 
-#: accounts/admin.py:32
+#: accounts/admin.py:34 accounts/admin.py:61
 msgid "email"
 msgstr "Courrier électronique"
 
-#: accounts/admin.py:39
-msgid "active"
-msgstr ""
-
-#: accounts/admin.py:45
+#: accounts/admin.py:67
 msgid "date joined"
 msgstr ""
 
-#: accounts/admin.py:51
+#: accounts/admin.py:73
 msgid "last login"
 msgstr ""
 
@@ -1683,7 +1679,6 @@ msgid "Activation email sent"
 msgstr "Mail de confirmation envoyé"
 
 #: templates/registration/registration_complete.html:7
-#: tests/registration/test_registration.py:145
 msgid "An activation mail will be sent to you email address."
 msgstr "Un mail de confirmation va vous être envoyé"
 
@@ -1716,7 +1711,6 @@ msgid "Your username will be visible to other users. Don't use spaces or special
 msgstr "Attention le nom d'utilisateur est visible pour les autres utilisateurs. Veillez à ne pas utiliser d'espaces ou de signes spéciaux. "
 
 #: templates/registration/registration_form.html:51
-#: tests/registration/test_registration.py:131
 msgid "The two password fields didn't match."
 msgstr "Les deux mot de passe entrés diffèrent."
 
@@ -1735,18 +1729,6 @@ msgstr ""
 #: templates/registration/registration_form.html:76
 msgid "Sign-up"
 msgstr "Inscrire"
-
-#: tests/registration/test_registration.py:43
-msgid "This field is required."
-msgstr "Le champs est obligatoire"
-
-#: tests/registration/test_registration.py:82
-msgid "Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr "Veuillez choisir un nom d'utilisateur valable. Les signes spéciaux autorisés sont : @/./+/-/_"
-
-#: tests/registration/test_registration.py:110
-msgid "A user with that username already exists."
-msgstr "Il existe déjà un compte sous ce nom d'utilisateur."
 
 #: volunteer_planner/settings/base.py:149
 msgid "English"

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-16 10:07+0100\n"
+"POT-Creation-Date: 2022-03-16 23:25+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/coders4help/volunteer-planner/language/hu/)\n"
@@ -24,23 +24,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: accounts/admin.py:20 accounts/admin.py:26
+#: accounts/admin.py:22 accounts/admin.py:28
 msgid "first name"
 msgstr ""
 
-#: accounts/admin.py:32
+#: accounts/admin.py:34 accounts/admin.py:61
 msgid "email"
 msgstr "e-mail"
 
-#: accounts/admin.py:39
-msgid "active"
-msgstr ""
-
-#: accounts/admin.py:45
+#: accounts/admin.py:67
 msgid "date joined"
 msgstr ""
 
-#: accounts/admin.py:51
+#: accounts/admin.py:73
 msgid "last login"
 msgstr ""
 
@@ -1616,7 +1612,6 @@ msgid "Activation email sent"
 msgstr "Az akitváló e-mailt elküldtük!"
 
 #: templates/registration/registration_complete.html:7
-#: tests/registration/test_registration.py:145
 msgid "An activation mail will be sent to you email address."
 msgstr "A regisztrációt aktiváló e-mailt küldünk az e-mail címedre."
 
@@ -1649,7 +1644,6 @@ msgid "Your username will be visible to other users. Don't use spaces or special
 msgstr ""
 
 #: templates/registration/registration_form.html:51
-#: tests/registration/test_registration.py:131
 msgid "The two password fields didn't match."
 msgstr "A két jelszó nem egyezik!"
 
@@ -1668,18 +1662,6 @@ msgstr ""
 #: templates/registration/registration_form.html:76
 msgid "Sign-up"
 msgstr "Regisztráció"
-
-#: tests/registration/test_registration.py:43
-msgid "This field is required."
-msgstr "Kötelezően megadandó érték."
-
-#: tests/registration/test_registration.py:82
-msgid "Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr "Egy érvényes felhasználói nevet adj meg, ami betüből, számból és a következő karakterekből állhat: @/./+/-/_ "
-
-#: tests/registration/test_registration.py:110
-msgid "A user with that username already exists."
-msgstr "Ezzel a felhasználónévvel már létezik felhasználó."
 
 #: volunteer_planner/settings/base.py:149
 msgid "English"

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-16 10:07+0100\n"
+"POT-Creation-Date: 2022-03-16 23:25+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/coders4help/volunteer-planner/language/pt/)\n"
@@ -19,23 +19,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: accounts/admin.py:20 accounts/admin.py:26
+#: accounts/admin.py:22 accounts/admin.py:28
 msgid "first name"
 msgstr "nome"
 
-#: accounts/admin.py:32
+#: accounts/admin.py:34 accounts/admin.py:61
 msgid "email"
 msgstr "e-mail"
 
-#: accounts/admin.py:39
-msgid "active"
-msgstr ""
-
-#: accounts/admin.py:45
+#: accounts/admin.py:67
 msgid "date joined"
 msgstr ""
 
-#: accounts/admin.py:51
+#: accounts/admin.py:73
 msgid "last login"
 msgstr ""
 
@@ -1593,7 +1589,6 @@ msgid "Activation email sent"
 msgstr "Mensagem de ativação enviada"
 
 #: templates/registration/registration_complete.html:7
-#: tests/registration/test_registration.py:145
 msgid "An activation mail will be sent to you email address."
 msgstr ""
 
@@ -1626,7 +1621,6 @@ msgid "Your username will be visible to other users. Don't use spaces or special
 msgstr ""
 
 #: templates/registration/registration_form.html:51
-#: tests/registration/test_registration.py:131
 msgid "The two password fields didn't match."
 msgstr ""
 
@@ -1645,18 +1639,6 @@ msgstr ""
 #: templates/registration/registration_form.html:76
 msgid "Sign-up"
 msgstr "Registar"
-
-#: tests/registration/test_registration.py:43
-msgid "This field is required."
-msgstr "Este campo é obrigatório."
-
-#: tests/registration/test_registration.py:82
-msgid "Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr ""
-
-#: tests/registration/test_registration.py:110
-msgid "A user with that username already exists."
-msgstr ""
 
 #: volunteer_planner/settings/base.py:149
 msgid "English"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-16 10:07+0100\n"
+"POT-Creation-Date: 2022-03-16 23:25+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/coders4help/volunteer-planner/language/sv/)\n"
@@ -21,23 +21,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: accounts/admin.py:20 accounts/admin.py:26
+#: accounts/admin.py:22 accounts/admin.py:28
 msgid "first name"
 msgstr "förnamn"
 
-#: accounts/admin.py:32
+#: accounts/admin.py:34 accounts/admin.py:61
 msgid "email"
 msgstr "e-post"
 
-#: accounts/admin.py:39
-msgid "active"
-msgstr ""
-
-#: accounts/admin.py:45
+#: accounts/admin.py:67
 msgid "date joined"
 msgstr ""
 
-#: accounts/admin.py:51
+#: accounts/admin.py:73
 msgid "last login"
 msgstr ""
 
@@ -1655,7 +1651,6 @@ msgid "Activation email sent"
 msgstr "Ett aktiveringsmejl har skickats"
 
 #: templates/registration/registration_complete.html:7
-#: tests/registration/test_registration.py:145
 msgid "An activation mail will be sent to you email address."
 msgstr "Ett aktiveringsmejl kommer att skickas till din e-postadress."
 
@@ -1688,7 +1683,6 @@ msgid "Your username will be visible to other users. Don't use spaces or special
 msgstr ""
 
 #: templates/registration/registration_form.html:51
-#: tests/registration/test_registration.py:131
 msgid "The two password fields didn't match."
 msgstr "Lösenorden stämmer inte överens."
 
@@ -1707,18 +1701,6 @@ msgstr ""
 #: templates/registration/registration_form.html:76
 msgid "Sign-up"
 msgstr "Skapa konto"
-
-#: tests/registration/test_registration.py:43
-msgid "This field is required."
-msgstr "Detta fält är nödvändigt."
-
-#: tests/registration/test_registration.py:82
-msgid "Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr "Ange ett giltigt användarnamn. Det får endast bestå av bokstäver, siffror och följande tecken: @/./+/-/_. "
-
-#: tests/registration/test_registration.py:110
-msgid "A user with that username already exists."
-msgstr "Det finns redan en användare med det här användarnamnet."
 
 #: volunteer_planner/settings/base.py:149
 msgid "English"

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-16 10:07+0100\n"
+"POT-Creation-Date: 2022-03-16 23:25+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/coders4help/volunteer-planner/language/tr/)\n"
@@ -18,23 +18,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: accounts/admin.py:20 accounts/admin.py:26
+#: accounts/admin.py:22 accounts/admin.py:28
 msgid "first name"
 msgstr ""
 
-#: accounts/admin.py:32
+#: accounts/admin.py:34 accounts/admin.py:61
 msgid "email"
 msgstr "e-posta"
 
-#: accounts/admin.py:39
-msgid "active"
-msgstr ""
-
-#: accounts/admin.py:45
+#: accounts/admin.py:67
 msgid "date joined"
 msgstr ""
 
-#: accounts/admin.py:51
+#: accounts/admin.py:73
 msgid "last login"
 msgstr ""
 
@@ -1592,7 +1588,6 @@ msgid "Activation email sent"
 msgstr "Aktivasyon e-postası gönderildi"
 
 #: templates/registration/registration_complete.html:7
-#: tests/registration/test_registration.py:145
 msgid "An activation mail will be sent to you email address."
 msgstr "Aktivasyon e-postası, e-posta adresinize gönderilecek."
 
@@ -1625,7 +1620,6 @@ msgid "Your username will be visible to other users. Don't use spaces or special
 msgstr ""
 
 #: templates/registration/registration_form.html:51
-#: tests/registration/test_registration.py:131
 msgid "The two password fields didn't match."
 msgstr ""
 
@@ -1644,18 +1638,6 @@ msgstr ""
 #: templates/registration/registration_form.html:76
 msgid "Sign-up"
 msgstr "Kaydol"
-
-#: tests/registration/test_registration.py:43
-msgid "This field is required."
-msgstr ""
-
-#: tests/registration/test_registration.py:82
-msgid "Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr ""
-
-#: tests/registration/test_registration.py:110
-msgid "A user with that username already exists."
-msgstr "Bu kullanıcı adıyla kaydolmuş bir kullanıcı mevcut."
 
 #: volunteer_planner/settings/base.py:149
 msgid "English"

--- a/tests/registration/test_registration.py
+++ b/tests/registration/test_registration.py
@@ -1,29 +1,34 @@
 # coding=utf-8
-from django.test import TestCase
-from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
 import pytest
 
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
 from registration.models import RegistrationProfile
+
 from accounts.models import UserAccount
 
 
+@override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
 class RegistrationTestCase(TestCase):
     def setUp(self):
         # TODO: fix typo in url name in urls.py
-        self.registration_url = reverse('registration_register')
+        self.registration_url = reverse("registration_register")
 
-        self.valid_user_data = {'username': 'somename',
-                                'email': 'somename@example.de',
-                                'password1': 'somepassword',
-                                'password2': 'somepassword'}
+        self.valid_user_data = {
+            "username": "somename",
+            "email": "somename@example.de",
+            "password1": "somepassword",
+            "password2": "somepassword",
+            "accept_privacy_policy": True,
+        }
 
     def test_get_displays_empty_form(self):
         response = self.client.get(self.registration_url)
         assert response.status_code == 200
-        self.assertTemplateUsed(response, 'registration/registration_form.html')
+        self.assertTemplateUsed(response, "registration/registration_form.html")
 
-        form = response.context['form']
+        form = response.context["form"]
         assert form is not None
 
         initial_data = form.initial
@@ -33,27 +38,25 @@ class RegistrationTestCase(TestCase):
         # shall not raise an exception
         response = self.client.post(self.registration_url, {})
 
-        form = response.context['form']
-        assert form is not None, 'We expect the form to be displayed again if the submission failed'
+        form = response.context["form"]
+        assert form is not None, "We expect the form to be displayed again if the submission failed"
 
-        self.assertFormError(
-            response,
-            'form',
-            'email',
-            _('This field is required.'))
+        self.assertFormError(response, "form", "email", "This field is required.")
 
         assert RegistrationProfile.objects.count() == 0
 
     def test_invalid_email(self):
-        user_data = {'username': 'somename',
-                     'email': 'invalid-address',
-                     'password1': 'somepassword',
-                     'password2': 'differentpassword'}
+        user_data = {
+            "username": "somename",
+            "email": "invalid-address",
+            "password1": "somepassword",
+            "password2": "differentpassword",
+        }
 
         response = self.client.post(self.registration_url, user_data)
 
-        form = response.context['form']
-        assert form is not None, 'We expect the form to be displayed again if the submission failed'
+        form = response.context["form"]
+        assert form is not None, "We expect the form to be displayed again if the submission failed"
 
         # TODO: implement form error and then assertFormError
         # see for example test_username_exists_already
@@ -64,85 +67,76 @@ class RegistrationTestCase(TestCase):
         """
         helper method for the next couple of tests checking invalid usernames
         """
-        user_data = {'username': invalid_username,
-                     'email': 'somename@example.de',
-                     'password1': 'somepassword',
-                     'password2': 'somepassword'}
+        user_data = {
+            "username": invalid_username,
+            "email": "somename@example.de",
+            "password1": "somepassword",
+            "password2": "somepassword",
+        }
 
         response = self.client.post(self.registration_url, user_data)
 
-        form = response.context['form']
-        assert form is not None, 'We expect the form to be displayed again if the submission failed'
+        form = response.context["form"]
+        assert form is not None, "We expect the form to be displayed again if the submission failed"
 
         self.assertFormError(
             response,
-            'form',
-            'username',
-            _(
-                'Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters.'))
+            "form",
+            "username",
+            "Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters.",
+        )
 
         assert RegistrationProfile.objects.count() == 0
 
     def test_username_with_whitespaces(self):
-        self.try_invalid_username('some invalid name')
+        self.try_invalid_username("some invalid name")
 
     def test_username_with_special_chars(self):
-        self.try_invalid_username('someinvalidname$')
+        self.try_invalid_username("someinvalidname$")
 
     def test_username_with_umlauts(self):
-        self.try_invalid_username(unicode('somename\xc3', errors='replace'))
+        self.try_invalid_username("somename with ÖÄÜäöüß")
 
     def test_username_exists_already(self):
         # register first user
         self.client.post(self.registration_url, self.valid_user_data)
 
         # try to register user again (=same username)
-        response = self.client.post(self.registration_url,
-                                    self.valid_user_data)
+        response = self.client.post(self.registration_url, self.valid_user_data)
 
-        form = response.context['form']
-        assert form is not None, 'We expect the form to be displayed again if the submission failed'
+        form = response.context["form"]
+        assert form is not None, "We expect the form to be displayed again if the submission failed"
 
-        self.assertFormError(
-            response,
-            'form',
-            'username',
-            _(u'A user with that username already exists.'))
+        self.assertFormError(response, "form", "username", "A user with that username already exists.")
 
         assert RegistrationProfile.objects.count() == 1
 
     def test_passwords_dont_match(self):
-        user_data = {'username': 'somename',
-                     'email': 'somename@example.de',
-                     'password1': 'somepassword',
-                     'password2': 'differentpassword'}
+        user_data = {
+            "username": "somename",
+            "email": "somename@example.de",
+            "password1": "somepassword",
+            "password2": "differentpassword",
+        }
 
         response = self.client.post(self.registration_url, user_data)
 
-        form = response.context['form']
-        assert form is not None, 'We expect the form to be displayed again if the submission failed'
+        form = response.context["form"]
+        assert form is not None, "We expect the form to be displayed again if the submission failed"
 
         # TODO: why is this a non-field error? Shouldn't it be a error on the
         # second password field?
-        self.assertFormError(
-            response,
-            'form',
-            'password2',
-            _("The two password fields didn't match."))
+        self.assertFormError(response, "form", "password2", "The two password fields didn't match.")
 
         assert RegistrationProfile.objects.count() == 0
 
     def test_submit_valid_form(self):
-        response = self.client.post(self.registration_url,
-                                    self.valid_user_data,
-                                    follow=True)
+        response = self.client.post(self.registration_url, self.valid_user_data, follow=True)
 
-        registration_complete_url = reverse('registration_complete')
+        registration_complete_url = reverse("registration_complete")
 
         self.assertRedirects(response, registration_complete_url)
-        self.assertContains(
-            response,
-            _(u'An activation mail will be sent to you email address.'))
+        self.assertContains(response, "An activation mail will be sent to you email address.")
 
         assert RegistrationProfile.objects.count() == 1
         new_user = RegistrationProfile.objects.first()
@@ -166,18 +160,20 @@ class RegistrationTestCase(TestCase):
         assert not new_user.user.is_active
 
         activation_key = new_user.activation_key
-        activation_url = reverse('registration_activate',
-                                 args=[activation_key, ])
+        activation_url = reverse(
+            "registration_activate",
+            args=[
+                activation_key,
+            ],
+        )
 
-        response = self.client.get(activation_url,
-                                   follow=True)
+        response = self.client.get(activation_url, follow=True)
 
-        activation_complete_url = reverse('registration_activation_complete')
+        activation_complete_url = reverse("registration_activation_complete")
 
         self.assertRedirects(response, activation_complete_url)
 
-        user_from_regprofile = RegistrationProfile.objects.get(
-            user=new_user.user).user
+        user_from_regprofile = RegistrationProfile.objects.get(user=new_user.user).user
         user_from_account = UserAccount.objects.get(user=new_user.user).user
 
         assert user_from_account == user_from_regprofile


### PR DESCRIPTION
Use source language in unit tests to make them independent from l10n, and check error messages in english.