### PR TITLE
Change python to python3

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 import os
 import sys


### PR DESCRIPTION
There exists some runtime environment without runtime binary name
"python".
