### PR TITLE
Improve `makemessages.sh`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,7 +26,7 @@ jobs:
       # apt install system dependencies
       - name: Install apt packages
         run: |
-          sudo apt install -y gettext 
+          sudo apt install -y gettext
 
       # Pip install project dependencies
       - name: Install python packages with pip
@@ -38,7 +38,6 @@ jobs:
       - name: Check for missing messages in .po files
         run: |
           ./makemessages.sh
-          git diff --ignore-matching-lines=POT-Creation-Date --exit-code
 
       # Check for missing Django migrations
       - name: Check for missing Django migrations

--- a/makemessages.sh
+++ b/makemessages.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
-cmd="./manage.py makemessages --all --no-wrap --no-location --no-obsolete"
+
+cmd="./manage.py makemessages --no-wrap --no-location --no-obsolete $@"
 echo "${cmd}"
 ${cmd}
+echo "Done."
+echo
+echo "Checking for changes in .po files..."
+git diff --ignore-matching-lines=POT-Creation-Date --exit-code -- '***.po'
+
+diff_result=$?
+test $diff_result -eq 0 && echo "No changed messages found."
+echo
+exit $diff_result


### PR DESCRIPTION
You can now specify a language: arguments to `makemessages.sh` are now passed to `makemessages`. When no language is specified, `makemessages` will update all languages.

Also, after `makemessages` is run, the diff is checked for non-trivial changes (aka. is any other change other than `POT-Creation-Date` present?) and a non-zero exit code is returned. This is used in the GitHub workflow to check if any messages are are missing for any translation.