### PR TITLE
Run makemessages.sh with --all in workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,7 +37,7 @@ jobs:
       # Check for missing messages in .po files
       - name: Check for missing messages in .po files
         run: |
-          ./makemessages.sh
+          ./makemessages.sh --all
 
       # Check for missing Django migrations
       - name: Check for missing Django migrations


### PR DESCRIPTION
This prevents errors later (on django 4), when the management command makemessages no longer defaults to --all.