### PR TITLE
Fix included requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,6 @@
 -r base.txt
+-r tests.txt
+
 black==22.1.0
 coverage==4.5.3
 django-debug-toolbar==2.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,2 +1,1 @@
 -r base.txt
--r dev.txt


### PR DESCRIPTION
`tests` do not depend on `dev` but the other way around.