### PR TITLE
Adjust flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,7 @@
 per-file-ignores =
    volunteer_planner/settings/*.py: F403, F405,
    volunteer_planner/settings/__init__.py: F403,
+
+max-line-length = 88
+select = C,E,F,W,B,B950
+extend-ignore = E203, E501


### PR DESCRIPTION
Default flake8 configuration collides with results black produces.
Adjust line length settings for flake8 checks to respect black format.
