### PR TITLE
Restrict new usernames

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -5,32 +5,19 @@ from django.utils.text import gettext_lazy as _
 from registration.forms import RegistrationFormUniqueEmail
 
 username_first_char_validator = RegexValidator(
-    r"^[a-zA-Z]", _("Username must start with a letter.")
+    r"^[_.0-9\s]", _("Username must start with a letter."),
+    inverse_match=True
 )
 username_validator = RegexValidator(
-    r"^[a-zA-Z0-9_.]*$",
+    r"[^\w.]",
     _('Invalid username. Allowed characters are letters, numbers, "." and "_".'),
+    inverse_match=True
 )
 username_last_char_validator = RegexValidator(
-    r"[a-zA-Z0-9]$", _("Username must end with a letter or a number.")
+    r"[\w]$", _("Username must end with a letter or a number.")
 )
-no_consequtive_dots = RegexValidator(
-    r"\.\.",
-    _("Username must not contain consecutive . or _ characters."),
-    inverse_match=True,
-)
-no_consequtive_underscores = RegexValidator(
-    r"__",
-    _("Username must not contain consecutive . or _ characters."),
-    inverse_match=True,
-)
-no_consequtive_funnystuff = RegexValidator(
-    r"_\.",
-    _("Username must not contain consecutive . or _ characters."),
-    inverse_match=True,
-)
-no_consequtive_funnystuff2 = RegexValidator(
-    r"\._",
+no_consequtive = RegexValidator(
+    r"[_.]{2,}",
     _("Username must not contain consecutive . or _ characters."),
     inverse_match=True,
 )
@@ -46,10 +33,7 @@ class RegistrationForm(RegistrationFormUniqueEmail):
             username_first_char_validator,
             username_validator,
             username_last_char_validator,
-            no_consequtive_dots,
-            no_consequtive_underscores,
-            no_consequtive_funnystuff,
-            no_consequtive_funnystuff2,
+            no_consequtive,
         ],
     )
 

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,9 +1,58 @@
 from django import forms
+from django.core.validators import RegexValidator
 from django.utils.text import gettext_lazy as _
+
 from registration.forms import RegistrationFormUniqueEmail
+
+username_first_char_validator = RegexValidator(
+    r"^[a-zA-Z]", _("Username must start with a letter.")
+)
+username_validator = RegexValidator(
+    r"^[a-zA-Z0-9_.]*$",
+    _('Invalid username. Allowed characters are letters, numbers, "." and "_".'),
+)
+username_last_char_validator = RegexValidator(
+    r"[a-zA-Z0-9]$", _("Username must end with a letter or a number.")
+)
+no_consequtive_dots = RegexValidator(
+    r"\.\.",
+    _("Username must not contain consecutive . or _ characters."),
+    inverse_match=True,
+)
+no_consequtive_underscores = RegexValidator(
+    r"__",
+    _("Username must not contain consecutive . or _ characters."),
+    inverse_match=True,
+)
+no_consequtive_funnystuff = RegexValidator(
+    r"_\.",
+    _("Username must not contain consecutive . or _ characters."),
+    inverse_match=True,
+)
+no_consequtive_funnystuff2 = RegexValidator(
+    r"\._",
+    _("Username must not contain consecutive . or _ characters."),
+    inverse_match=True,
+)
 
 
 class RegistrationForm(RegistrationFormUniqueEmail):
+
+    username = forms.CharField(
+        max_length=16,
+        min_length=3,
+        strip=False,
+        validators=[
+            username_first_char_validator,
+            username_validator,
+            username_last_char_validator,
+            no_consequtive_dots,
+            no_consequtive_underscores,
+            no_consequtive_funnystuff,
+            no_consequtive_funnystuff2,
+        ],
+    )
+
     accept_privacy_policy = forms.BooleanField(
         required=True, initial=False, label=_("Accept privacy policy")
     )

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -4,17 +4,16 @@ from django.utils.text import gettext_lazy as _
 
 from registration.forms import RegistrationFormUniqueEmail
 
-username_first_char_validator = RegexValidator(
-    r"^[_.0-9\s]", _("Username must start with a letter."),
-    inverse_match=True
-)
 username_validator = RegexValidator(
     r"[^\w.]",
     _('Invalid username. Allowed characters are letters, numbers, "." and "_".'),
-    inverse_match=True
+    inverse_match=True,
+)
+username_first_char_validator = RegexValidator(
+    r"^[_.0-9\s]", _("Username must start with a letter."), inverse_match=True
 )
 username_last_char_validator = RegexValidator(
-    r"[\w]$", _("Username must end with a letter or a number.")
+    r"[\w]$", _('Username must end with a letter, a number or "_".')
 )
 no_consequtive = RegexValidator(
     r"[_.]{2,}",
@@ -30,8 +29,8 @@ class RegistrationForm(RegistrationFormUniqueEmail):
         min_length=3,
         strip=False,
         validators=[
-            username_first_char_validator,
             username_validator,
+            username_first_char_validator,
             username_last_char_validator,
             no_consequtive,
         ],

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -10,7 +10,7 @@ username_validator = RegexValidator(
     inverse_match=True,
 )
 username_first_char_validator = RegexValidator(
-    r"^[_.0-9\s]", _("Username must start with a letter."), inverse_match=True
+    r"^[\d_.]", _("Username must start with a letter."), inverse_match=True
 )
 username_last_char_validator = RegexValidator(
     r"[\w]$", _('Username must end with a letter, a number or "_".')
@@ -25,7 +25,7 @@ no_consequtive = RegexValidator(
 class RegistrationForm(RegistrationFormUniqueEmail):
 
     username = forms.CharField(
-        max_length=16,
+        max_length=32,
         min_length=3,
         strip=False,
         validators=[

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2022-03-15 17:56+0000\n"
 "Last-Translator: Christoph Meißner\n"
 "Language-Team: Arabic (http://www.transifex.com/coders4help/volunteer-planner/language/ar/)\n"
@@ -36,13 +36,13 @@ msgstr ""
 msgid "Accounts"
 msgstr "الحسابات "
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2022-03-15 17:56+0000\n"
 "Last-Translator: Christoph Meißner\n"
 "Language-Team: Arabic (http://www.transifex.com/coders4help/volunteer-planner/language/ar/)\n"
@@ -35,6 +35,18 @@ msgstr ""
 
 msgid "Accounts"
 msgstr "الحسابات "
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
+msgstr ""
 
 msgid "Accept privacy policy"
 msgstr ""

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2022-03-15 17:56+0000\n"
 "Last-Translator: Christoph Meißner\n"
 "Language-Team: Bulgarian (http://www.transifex.com/coders4help/volunteer-planner/language/bg/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2022-03-15 17:56+0000\n"
 "Last-Translator: Christoph Meißner\n"
 "Language-Team: Bulgarian (http://www.transifex.com/coders4help/volunteer-planner/language/bg/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2022-03-15 17:56+0000\n"
 "Last-Translator: Christoph Meißner\n"
 "Language-Team: Czech (http://www.transifex.com/coders4help/volunteer-planner/language/cs/)\n"
@@ -34,13 +34,13 @@ msgstr "poslední přihlášení"
 msgid "Accounts"
 msgstr "Účty"
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2022-03-15 17:56+0000\n"
 "Last-Translator: Christoph Meißner\n"
 "Language-Team: Czech (http://www.transifex.com/coders4help/volunteer-planner/language/cs/)\n"
@@ -33,6 +33,18 @@ msgstr "poslední přihlášení"
 
 msgid "Accounts"
 msgstr "Účty"
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
+msgstr ""
 
 msgid "Accept privacy policy"
 msgstr "Přijmout zásady ochrany osobních údajů"

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2017-09-22 15:35+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Danish (http://www.transifex.com/coders4help/volunteer-planner/language/da/)\n"
@@ -33,13 +33,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2017-09-22 15:35+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Danish (http://www.transifex.com/coders4help/volunteer-planner/language/da/)\n"
@@ -31,6 +31,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-11-21 18:24+0000\n"
 "Last-Translator: Sönke Klinger <klinger@biver.de>\n"
 "Language-Team: German (http://www.transifex.com/coders4help/volunteer-planner/language/de/)\n"
@@ -47,14 +47,14 @@ msgstr "Letzte Anmeldung"
 msgid "Accounts"
 msgstr "Benutzerkonten"
 
-msgid "Username must start with a letter."
-msgstr "Benutzername muss mit einem Buchstaben anfangen."
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr "Ungültiger Benutzername. Erlaubte Zeichen sind Buchstaben, Ziffern, \".\" and \".\"."
 
-msgid "Username must end with a letter or a number."
-msgstr "Benutzername muss mit einem Buchstaben oder einer Ziffer enden."
+msgid "Username must start with a letter."
+msgstr "Benutzername muss mit einem Buchstaben anfangen."
+
+msgid "Username must end with a letter, a number or \"_\"."
+msgstr "Benutzername muss mit einem Buchstaben, einer Ziffer oder \"_\" enden."
 
 msgid "Username must not contain consecutive . or _ characters."
 msgstr "Benutzername darf keine aufeinanderfolgenden . oder _ enthalten."

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-11-21 18:24+0000\n"
 "Last-Translator: Sönke Klinger <klinger@biver.de>\n"
 "Language-Team: German (http://www.transifex.com/coders4help/volunteer-planner/language/de/)\n"
@@ -46,6 +46,18 @@ msgstr "Letzte Anmeldung"
 
 msgid "Accounts"
 msgstr "Benutzerkonten"
+
+msgid "Username must start with a letter."
+msgstr "Benutzername muss mit einem Buchstaben anfangen."
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr "Ungültiger Benutzername. Erlaubte Zeichen sind Buchstaben, Ziffern, \".\" and \".\"."
+
+msgid "Username must end with a letter or a number."
+msgstr "Benutzername muss mit einem Buchstaben oder einer Ziffer enden."
+
+msgid "Username must not contain consecutive . or _ characters."
+msgstr "Benutzername darf keine aufeinanderfolgenden . oder _ enthalten."
 
 msgid "Accept privacy policy"
 msgstr "Einwilligung (nach Art 6 Abs 1 Satz 1 a DSGVO)"

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Greek (http://www.transifex.com/coders4help/volunteer-planner/language/el/)\n"
@@ -36,6 +36,18 @@ msgstr ""
 
 msgid "Accounts"
 msgstr "Λογαριασμοί"
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
+msgstr ""
 
 msgid "Accept privacy policy"
 msgstr ""

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Greek (http://www.transifex.com/coders4help/volunteer-planner/language/el/)\n"
@@ -37,13 +37,13 @@ msgstr ""
 msgid "Accounts"
 msgstr "Λογαριασμοί"
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2015-10-04 21:53+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: English (http://www.transifex.com/coders4help/volunteer-planner/language/en/)\n"
@@ -29,13 +29,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2015-10-04 21:53+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: English (http://www.transifex.com/coders4help/volunteer-planner/language/en/)\n"
@@ -27,6 +27,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-04-13 17:27+0000\n"
 "Last-Translator: Antonio Mireles <antonio@mirelesindependent.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/coders4help/volunteer-planner/language/es/)\n"
@@ -36,13 +36,13 @@ msgstr ""
 msgid "Accounts"
 msgstr "Cuentas"
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-04-13 17:27+0000\n"
 "Last-Translator: Antonio Mireles <antonio@mirelesindependent.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/coders4help/volunteer-planner/language/es/)\n"
@@ -35,6 +35,18 @@ msgstr ""
 
 msgid "Accounts"
 msgstr "Cuentas"
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
+msgstr ""
 
 msgid "Accept privacy policy"
 msgstr ""

--- a/locale/es_MX/LC_MESSAGES/django.po
+++ b/locale/es_MX/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/coders4help/volunteer-planner/language/es_MX/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/es_MX/LC_MESSAGES/django.po
+++ b/locale/es_MX/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/coders4help/volunteer-planner/language/es_MX/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Persian (http://www.transifex.com/coders4help/volunteer-planner/language/fa/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Persian (http://www.transifex.com/coders4help/volunteer-planner/language/fa/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-12-08 20:50+0000\n"
 "Last-Translator: Dolfeus <dolfeus@sfr.fr>\n"
 "Language-Team: French (http://www.transifex.com/coders4help/volunteer-planner/language/fr/)\n"
@@ -38,13 +38,13 @@ msgstr ""
 msgid "Accounts"
 msgstr "Comptes utilisateur"
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-12-08 20:50+0000\n"
 "Last-Translator: Dolfeus <dolfeus@sfr.fr>\n"
 "Language-Team: French (http://www.transifex.com/coders4help/volunteer-planner/language/fr/)\n"
@@ -37,6 +37,18 @@ msgstr ""
 
 msgid "Accounts"
 msgstr "Comptes utilisateur"
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
+msgstr ""
 
 msgid "Accept privacy policy"
 msgstr ""

--- a/locale/hr/LC_MESSAGES/django.po
+++ b/locale/hr/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Croatian (http://www.transifex.com/coders4help/volunteer-planner/language/hr/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/hr/LC_MESSAGES/django.po
+++ b/locale/hr/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Croatian (http://www.transifex.com/coders4help/volunteer-planner/language/hr/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/coders4help/volunteer-planner/language/hu/)\n"
@@ -40,6 +40,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/coders4help/volunteer-planner/language/hu/)\n"
@@ -42,13 +42,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/hy/LC_MESSAGES/django.po
+++ b/locale/hy/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Armenian (http://www.transifex.com/coders4help/volunteer-planner/language/hy/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/hy/LC_MESSAGES/django.po
+++ b/locale/hy/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Armenian (http://www.transifex.com/coders4help/volunteer-planner/language/hy/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Italian (http://www.transifex.com/coders4help/volunteer-planner/language/it/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Italian (http://www.transifex.com/coders4help/volunteer-planner/language/it/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/coders4help/volunteer-planner/language/nl/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/coders4help/volunteer-planner/language/nl/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Norwegian (http://www.transifex.com/coders4help/volunteer-planner/language/no/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Norwegian (http://www.transifex.com/coders4help/volunteer-planner/language/no/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2017-09-22 15:29+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Polish (http://www.transifex.com/coders4help/volunteer-planner/language/pl/)\n"
@@ -36,13 +36,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2017-09-22 15:29+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Polish (http://www.transifex.com/coders4help/volunteer-planner/language/pl/)\n"
@@ -34,6 +34,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/coders4help/volunteer-planner/language/pt/)\n"
@@ -36,6 +36,18 @@ msgstr ""
 
 msgid "Accounts"
 msgstr "Contas"
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
+msgstr ""
 
 msgid "Accept privacy policy"
 msgstr ""

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/coders4help/volunteer-planner/language/pt/)\n"
@@ -37,13 +37,13 @@ msgstr ""
 msgid "Accounts"
 msgstr "Contas"
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/coders4help/volunteer-planner/language/pt_BR/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/coders4help/volunteer-planner/language/pt_BR/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Romanian (http://www.transifex.com/coders4help/volunteer-planner/language/ro/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Romanian (http://www.transifex.com/coders4help/volunteer-planner/language/ro/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2022-03-10 13:42+0000\n"
 "Last-Translator: Anna Dunn\n"
 "Language-Team: Russian (http://www.transifex.com/coders4help/volunteer-planner/language/ru/)\n"
@@ -36,13 +36,13 @@ msgstr ""
 msgid "Accounts"
 msgstr "Aккаунты"
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2022-03-10 13:42+0000\n"
 "Last-Translator: Anna Dunn\n"
 "Language-Team: Russian (http://www.transifex.com/coders4help/volunteer-planner/language/ru/)\n"
@@ -35,6 +35,18 @@ msgstr ""
 
 msgid "Accounts"
 msgstr "Aккаунты"
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
+msgstr ""
 
 msgid "Accept privacy policy"
 msgstr ""

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Slovak (http://www.transifex.com/coders4help/volunteer-planner/language/sk/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Slovak (http://www.transifex.com/coders4help/volunteer-planner/language/sk/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Slovenian (http://www.transifex.com/coders4help/volunteer-planner/language/sl/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Slovenian (http://www.transifex.com/coders4help/volunteer-planner/language/sl/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/sq/LC_MESSAGES/django.po
+++ b/locale/sq/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Albanian (http://www.transifex.com/coders4help/volunteer-planner/language/sq/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/sq/LC_MESSAGES/django.po
+++ b/locale/sq/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Albanian (http://www.transifex.com/coders4help/volunteer-planner/language/sq/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/sr_RS/LC_MESSAGES/django.po
+++ b/locale/sr_RS/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Serbian (Serbia) (http://www.transifex.com/coders4help/volunteer-planner/language/sr_RS/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/sr_RS/LC_MESSAGES/django.po
+++ b/locale/sr_RS/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Serbian (Serbia) (http://www.transifex.com/coders4help/volunteer-planner/language/sr_RS/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/coders4help/volunteer-planner/language/sv/)\n"
@@ -39,13 +39,13 @@ msgstr ""
 msgid "Accounts"
 msgstr "Konton"
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/coders4help/volunteer-planner/language/sv/)\n"
@@ -38,6 +38,18 @@ msgstr ""
 
 msgid "Accounts"
 msgstr "Konton"
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
+msgstr ""
 
 msgid "Accept privacy policy"
 msgstr ""

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/coders4help/volunteer-planner/language/tr/)\n"
@@ -33,13 +33,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/coders4help/volunteer-planner/language/tr/)\n"
@@ -31,6 +31,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/tr_TR/LC_MESSAGES/django.po
+++ b/locale/tr_TR/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/coders4help/volunteer-planner/language/tr_TR/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/tr_TR/LC_MESSAGES/django.po
+++ b/locale/tr_TR/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/coders4help/volunteer-planner/language/tr_TR/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/coders4help/volunteer-planner/language/uk/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/coders4help/volunteer-planner/language/uk/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 21:54+0100\n"
+"POT-Creation-Date: 2022-03-28 17:29+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/coders4help/volunteer-planner/language/zh_CN/)\n"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-msgid "Username must start with a letter."
-msgstr ""
-
 msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
 msgstr ""
 
-msgid "Username must end with a letter or a number."
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Username must end with a letter, a number or \"_\"."
 msgstr ""
 
 msgid "Username must not contain consecutive . or _ characters."

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-25 11:54+0100\n"
+"POT-Creation-Date: 2022-03-25 21:54+0100\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/coders4help/volunteer-planner/language/zh_CN/)\n"
@@ -30,6 +30,18 @@ msgid "last login"
 msgstr ""
 
 msgid "Accounts"
+msgstr ""
+
+msgid "Username must start with a letter."
+msgstr ""
+
+msgid "Invalid username. Allowed characters are letters, numbers, \".\" and \"_\"."
+msgstr ""
+
+msgid "Username must end with a letter or a number."
+msgstr ""
+
+msgid "Username must not contain consecutive . or _ characters."
 msgstr ""
 
 msgid "Accept privacy policy"

--- a/templates/registration/registration_form.html
+++ b/templates/registration/registration_form.html
@@ -24,7 +24,7 @@
                    class="form-control"
                    placeholder="{% trans "Email" %}"
                    name="email"
-                   value="{{ form.cleaned_data.email|default:form.email.value }}">
+                   value="{{ form.cleaned_data.email|default:form.email.value|default:"" }}">
              <p class="help-block">{% trans "Volunteer-Planner and shelters will send you emails concerning your shifts." %}</p>
         </div>
 
@@ -39,7 +39,7 @@
                    id="Username"
                    placeholder="{% trans "Username" %}"
                    name="username"
-                   value="{{ form.cleaned_data.username|default:form.username.value }}">
+                   value="{{ form.cleaned_data.username|default:form.username.value|default:"" }}">
             <p class="help-block">{% trans "Your username will be visible to other users. Don't use spaces or special characters." %}</p>
         </div>
 

--- a/templates/registration/registration_form.html
+++ b/templates/registration/registration_form.html
@@ -24,7 +24,7 @@
                    class="form-control"
                    placeholder="{% trans "Email" %}"
                    name="email"
-                   value="{{ form.cleaned_data.email }}">
+                   value="{{ form.cleaned_data.email|default:form.email.value }}">
              <p class="help-block">{% trans "Volunteer-Planner and shelters will send you emails concerning your shifts." %}</p>
         </div>
 
@@ -39,7 +39,7 @@
                    id="Username"
                    placeholder="{% trans "Username" %}"
                    name="username"
-                   value="{{ form.cleaned_data.username }}">
+                   value="{{ form.cleaned_data.username|default:form.username.value }}">
             <p class="help-block">{% trans "Your username will be visible to other users. Don't use spaces or special characters." %}</p>
         </div>
 

--- a/tests/registration/test_registration.py
+++ b/tests/registration/test_registration.py
@@ -135,8 +135,8 @@ class RegistrationTestCase(TestCase):
 
     def test_username_too_long(self):
         self.try_invalid_username(
-            "abcdef_0123456789",
-            "Ensure this value has at most 16 characters (it has 17).",
+            "abcdef0123456789.abcdef0123456789",
+            "Ensure this value has at most 32 characters (it has 33).",
         )
 
     def test_username_with_consequtive_underscores(self):
@@ -174,7 +174,6 @@ class RegistrationTestCase(TestCase):
         self.try_invalid_username(
             " username",
             [
-                "Username must start with a letter.",
                 "Invalid username. "
                 'Allowed characters are letters, numbers, "." and "_".',
             ],
@@ -190,7 +189,6 @@ class RegistrationTestCase(TestCase):
         self.try_invalid_username(
             " username ",
             [
-                "Username must start with a letter.",
                 'Username must end with a letter, a number or "_".',
                 "Invalid username. "
                 'Allowed characters are letters, numbers, "." and "_".',
@@ -199,7 +197,6 @@ class RegistrationTestCase(TestCase):
         self.try_invalid_username(
             " user name ",
             [
-                "Username must start with a letter.",
                 'Username must end with a letter, a number or "_".',
                 "Invalid username. "
                 'Allowed characters are letters, numbers, "." and "_".',

--- a/tests/registration/test_registration.py
+++ b/tests/registration/test_registration.py
@@ -125,7 +125,7 @@ class RegistrationTestCase(TestCase):
 
     def test_username_ending(self):
         self.try_invalid_username(
-            "username.", "Username must end with a letter or a number."
+            "username.", 'Username must end with a letter, a number or "_".'
         )
 
     def test_username_too_short(self):
@@ -182,7 +182,7 @@ class RegistrationTestCase(TestCase):
         self.try_invalid_username(
             "username ",
             [
-                "Username must end with a letter or a number.",
+                'Username must end with a letter, a number or "_".',
                 "Invalid username. "
                 'Allowed characters are letters, numbers, "." and "_".',
             ],
@@ -191,7 +191,7 @@ class RegistrationTestCase(TestCase):
             " username ",
             [
                 "Username must start with a letter.",
-                "Username must end with a letter or a number.",
+                'Username must end with a letter, a number or "_".',
                 "Invalid username. "
                 'Allowed characters are letters, numbers, "." and "_".',
             ],
@@ -200,7 +200,7 @@ class RegistrationTestCase(TestCase):
             " user name ",
             [
                 "Username must start with a letter.",
-                "Username must end with a letter or a number.",
+                'Username must end with a letter, a number or "_".',
                 "Invalid username. "
                 'Allowed characters are letters, numbers, "." and "_".',
             ],


### PR DESCRIPTION
New users may only select usernames following these rules:
* min 3, max 16 characters
* starts with a letter 
* ends with a letter, number or a `_`
* may only contain letters, numbers,`.`, `_`
* for readability: no consequtive (double) characters `.` or `_` or any combination of those two, (ie. no `..`, `__`, `._` or `_.`)

fixes #494