### PR TITLE
Reduce number of queries for places on helpdesk

### DIFF
--- a/scheduler/views.py
+++ b/scheduler/views.py
@@ -64,7 +64,11 @@ class HelpDesk(LoginRequiredMixin, TemplateView):
         facilities = (
             Facility.objects.with_open_shifts()
             .select_related(
-                "organization", "place", "place__area", "place__area__region"
+                "organization",
+                "place",
+                "place__area",
+                "place__area__region",
+                "place__area__region__country",
             )
             .prefetch_related(
                 Prefetch(


### PR DESCRIPTION
Adds place__area__region__country to select_related on Facility queryset. This reduces the number of db queries to 1 for the Facilities inkl. the places down to their countries, instead of n for the number of existing countries.