### PR TITLE
Make number of slots in shifts and templates > 0

### DIFF
--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -711,6 +711,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -926,9 +929,6 @@ msgstr[4] ""
 msgstr[5] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -910,9 +913,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -724,6 +724,9 @@ msgstr "dobrovolníci"
 msgid "scheduler"
 msgstr "Plánovač"
 
+msgid "slots"
+msgstr "sloty"
+
 msgid "number of needed volunteers"
 msgstr "počet potřebných dobrovolníků"
 
@@ -954,9 +957,6 @@ msgstr[3] "{num_shifts} směn bylo přidáno do {date}"
 
 msgid "Something didn't work. Sorry about that."
 msgstr "Něco nefunguje. Omlouvám se za to."
-
-msgid "slots"
-msgstr "sloty"
 
 msgid "from"
 msgstr "ok"

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -708,6 +708,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -911,9 +914,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -736,6 +736,9 @@ msgstr "Freiwillige"
 msgid "scheduler"
 msgstr "Schichtplaner"
 
+msgid "slots"
+msgstr "Plätze"
+
 msgid "number of needed volunteers"
 msgstr "Anz. benötigter Freiwillige"
 
@@ -977,9 +980,6 @@ msgstr[1] "{num_shifts} Schichten wurden am {date} hinzugefügt"
 
 msgid "Something didn't work. Sorry about that."
 msgstr "Entschuldigung, etwas hat nicht funktioniert."
-
-msgid "slots"
-msgstr "Plätze"
 
 msgid "from"
 msgstr "von"

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -739,6 +739,9 @@ msgstr "Εθελοντές."
 msgid "scheduler"
 msgstr "Προγραμματιστής"
 
+msgid "slots"
+msgstr "Βάρδιες"
+
 msgid "number of needed volunteers"
 msgstr "Αριθμός εθελοντών που χρειάζεσαι"
 
@@ -943,9 +946,6 @@ msgstr[1] "{num_shifts} βάρδιες προστέθηκαν στις {date}"
 
 msgid "Something didn't work. Sorry about that."
 msgstr "Φαίνεται πως κάτι δεν πήγε καλά. Ζητούμε συγγνώμη."
-
-msgid "slots"
-msgstr "Βάρδιες"
 
 msgid "from"
 msgstr "από"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -704,6 +704,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -907,9 +910,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -730,6 +730,9 @@ msgstr "voluntarios"
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr "horarios"
+
 msgid "number of needed volunteers"
 msgstr "número de voluntarios que se necesitan"
 
@@ -934,9 +937,6 @@ msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
 msgstr "Algo no funcionó. Sentimos que haya ocurrido."
-
-msgid "slots"
-msgstr "horarios"
 
 msgid "from"
 msgstr "de"

--- a/locale/es_MX/LC_MESSAGES/django.po
+++ b/locale/es_MX/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -910,9 +913,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -910,9 +913,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -728,6 +728,9 @@ msgstr "Bénévoles"
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr "opportunités"
+
 msgid "number of needed volunteers"
 msgstr " Nombre de volontaires nécessaires"
 
@@ -963,9 +966,6 @@ msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
 msgstr "Quelque chose à dysfonctionné. Prière de nous en excuser."
-
-msgid "slots"
-msgstr "opportunités"
 
 msgid "from"
 msgstr "de"

--- a/locale/hr/LC_MESSAGES/django.po
+++ b/locale/hr/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -913,9 +916,6 @@ msgstr[1] ""
 msgstr[2] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -717,6 +717,9 @@ msgstr ""
 msgid "scheduler"
 msgstr "Ütemező"
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr "a szükséges önkéntesek száma"
 
@@ -920,9 +923,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/hy/LC_MESSAGES/django.po
+++ b/locale/hy/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -910,9 +913,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -910,9 +913,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -910,9 +913,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -910,9 +913,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -711,6 +711,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr "Liczba potrzebnych wolontariuszy "
 
@@ -920,9 +923,6 @@ msgstr[2] ""
 msgstr[3] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -712,6 +712,9 @@ msgstr "voluntários"
 msgid "scheduler"
 msgstr "Agenda"
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr "número de voluntários necessários"
 
@@ -915,9 +918,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -910,9 +913,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -913,9 +916,6 @@ msgstr[1] ""
 msgstr[2] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -731,6 +731,9 @@ msgstr "волонтеры"
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr "временные интервалы"
+
 msgid "number of needed volunteers"
 msgstr "количество необходимых волонтеров"
 
@@ -973,9 +976,6 @@ msgstr[3] ""
 
 msgid "Something didn't work. Sorry about that."
 msgstr "Что-то не сработало. Извини за это."
-
-msgid "slots"
-msgstr "временные интервалы"
 
 msgid "from"
 msgstr "от"

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -916,9 +919,6 @@ msgstr[2] ""
 msgstr[3] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -916,9 +919,6 @@ msgstr[2] ""
 msgstr[3] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/sq/LC_MESSAGES/django.po
+++ b/locale/sq/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -910,9 +913,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/sr_RS/LC_MESSAGES/django.po
+++ b/locale/sr_RS/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -913,9 +916,6 @@ msgstr[1] ""
 msgstr[2] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -735,6 +735,9 @@ msgstr "volontärer"
 msgid "scheduler"
 msgstr "Schemaläggare"
 
+msgid "slots"
+msgstr "platser"
+
 msgid "number of needed volunteers"
 msgstr "antal volontärer som behövs"
 
@@ -939,9 +942,6 @@ msgstr[1] "{num_shifts} pass har lagts till den {date}"
 
 msgid "Something didn't work. Sorry about that."
 msgstr "Oj, det skedde ett fel. Vi beklagar."
-
-msgid "slots"
-msgstr "platser"
 
 msgid "from"
 msgstr "från"

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -708,6 +708,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr "İhtiyaç duyulan gönüllü sayısı"
 
@@ -911,9 +914,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/tr_TR/LC_MESSAGES/django.po
+++ b/locale/tr_TR/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -910,9 +913,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -916,9 +919,6 @@ msgstr[2] ""
 msgstr[3] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -707,6 +707,9 @@ msgstr ""
 msgid "scheduler"
 msgstr ""
 
+msgid "slots"
+msgstr ""
+
 msgid "number of needed volunteers"
 msgstr ""
 
@@ -907,9 +910,6 @@ msgid_plural "{num_shifts} shifts were added to {date}"
 msgstr[0] ""
 
 msgid "Something didn't work. Sorry about that."
-msgstr ""
-
-msgid "slots"
 msgstr ""
 
 msgid "from"

--- a/scheduler/migrations/0040_min_shift_slots.py
+++ b/scheduler/migrations/0040_min_shift_slots.py
@@ -1,0 +1,27 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+def make_min_slots(apps, schema_editor):
+
+    Shift = apps.get_model("schedule", "Shift")
+    Shift.objects.filter(slots__lte=0).update(slots=1)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("scheduler", "0039_delete_workdone"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="shift",
+            name="slots",
+            field=models.PositiveIntegerField(
+                help_text="number of needed volunteers",
+                validators=[django.core.validators.MinValueValidator(1)],
+                verbose_name="slots",
+            ),
+        ),
+    ]

--- a/scheduler/models.py
+++ b/scheduler/models.py
@@ -2,6 +2,7 @@
 import logging
 from datetime import time
 
+from django.core.validators import MinValueValidator
 from django.db import models
 from django.urls import reverse
 from django.utils.formats import localize
@@ -41,7 +42,13 @@ class Shift(models.Model):
     """
 
     # PositiveIntegerField instead of custom validation
-    slots = models.PositiveIntegerField(verbose_name=_("number of needed volunteers"))
+    slots = models.PositiveIntegerField(
+        verbose_name=_("slots"),
+        help_text=_("number of needed volunteers"),
+        validators=[
+            MinValueValidator(1),
+        ],
+    )
 
     task = models.ForeignKey(
         "organizations.Task", models.PROTECT, verbose_name=_("task")

--- a/scheduletemplates/migrations/0006_min_shift_slots.py
+++ b/scheduletemplates/migrations/0006_min_shift_slots.py
@@ -1,0 +1,28 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+def make_min_slots(apps, schema_editor):
+
+    ShiftTemplate = apps.get_model("scheduletemplates", "ShiftTemplate")
+    ShiftTemplate.objects.filter(slots__lte=0).update(slots=1)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("scheduletemplates", "0005_cascade_deletion"),
+    ]
+
+    operations = [
+        migrations.RunPython(make_min_slots, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="shifttemplate",
+            name="slots",
+            field=models.PositiveIntegerField(
+                help_text="number of needed volunteers",
+                validators=[django.core.validators.MinValueValidator(1)],
+                verbose_name="slots",
+            ),
+        ),
+    ]

--- a/scheduletemplates/models.py
+++ b/scheduletemplates/models.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from datetime import datetime, time, timedelta
 
+from django.core.validators import MinValueValidator
 from django.db import models
 from django.templatetags.l10n import localize
 from django.utils import timezone
@@ -39,7 +40,13 @@ class ShiftTemplate(models.Model):
         related_name="shift_templates",
     )
 
-    slots = models.IntegerField(verbose_name=_("number of needed volunteers"))
+    slots = models.PositiveIntegerField(
+        verbose_name=_("slots"),
+        help_text=_("number of needed volunteers"),
+        validators=[
+            MinValueValidator(1),
+        ],
+    )
 
     task = models.ForeignKey(
         "organizations.Task",


### PR DESCRIPTION
It was possible to create shift templates with zero or a negative number of slots, which led to a exception, when applying a schedule template including this shift template.