### PR TITLE
Sending e-mail on membership approval was broken

### DIFF
--- a/organizations/views.py
+++ b/organizations/views.py
@@ -148,7 +148,7 @@ def send_membership_approved_notification(membership, approved_by):
         to=addresses,
         from_email=from_email,
         reply_to=reply_to,
-        headers={'Sender': approved_by.email},
+        headers={"Sender": approved_by.email},
     )
     mail.send()
 

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -137,7 +137,7 @@ def send_membership_approved_notification(membership, approved_by):
     subject = _("volunteer-planner.org: Membership approved")
 
     from_email = settings.DEFAULT_FROM_EMAIL
-    reply_to = approved_by.email
+    reply_to = (approved_by.email,)
     to = membership.user_account.user.email
 
     addresses = (to,)
@@ -148,6 +148,7 @@ def send_membership_approved_notification(membership, approved_by):
         to=addresses,
         from_email=from_email,
         reply_to=reply_to,
+        headers={'Sender': approved_by.email},
     )
     mail.send()
 


### PR DESCRIPTION
Django4 migration broke e-mail creation.
This fixes "reply-to needs to be a list or tuple" and introduces an
additional header (sender).
