### PR TITLE
Disable dark mode for Dajngo admin

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,40 @@
+{% extends "admin/base_site.html" %}
+
+{% block extrastyle %}
+<style>
+    @media (prefers-color-scheme: dark) { 
+        :root {
+            --primary: #79aec8;
+            --primary-fg: #fff;
+
+            --body-fg: #333;
+            --body-bg: #fff;
+            --body-quiet-color: #666;
+            --body-loud-color: #000;
+
+            --breadcrumbs-fg: #c4dce8;
+            --breadcrumbs-bg: var(--primary);
+
+            --link-fg: #447e9b;
+            --link-hover-color: #036;
+            --link-selected-fg: #5b80b2;
+
+            --hairline-color: #e8e8e8;
+            --border-color: #ccc;
+
+            --error-fg: #ba2121;
+
+            --message-success-bg: #dfd;
+            --message-warning-bg: #ffc;
+            --message-error-bg: #ffefef;
+
+            --darkened-bg: #f8f8f8; /* A bit darker than --body-bg */
+            --selected-bg: #e4e4e4; /* E.g. selected table cells */
+            --selected-row: #ffc;
+
+            --close-button-bg: #888; /* Previously #bbb, contrast 1.92 */
+            --close-button-hover-bg: #747474;
+        }
+    }
+</style>
+{% endblock %}

--- a/volunteer_planner/settings/base.py
+++ b/volunteer_planner/settings/base.py
@@ -41,7 +41,6 @@ DJANGO_APPS = (
 
 THIRD_PARTY_APPS = (
     "ckeditor",
-    # A prettier theme
     "accounts.apps.RegistrationConfig",
     "django_ajax",
     "django_extensions",
@@ -162,8 +161,6 @@ LOCALE_PATHS = (SITE_ROOT + "/locale",)
 WSGI_APPLICATION = "%s.wsgi.application" % SITE_NAME
 
 FIXTURE_DIRS = (os.path.join(PROJECT_ROOT, "fixtures"),)
-CKEDITOR_JQUERY_URL = "//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"
-CKEDITOR_UPLOAD_PATH = "uploads/"
 
 DATE_FORMAT = "l, d.m.Y"
 

--- a/volunteer_planner/urls.py
+++ b/volunteer_planner/urls.py
@@ -15,7 +15,6 @@ urlpatterns = [
     re_path(r"^orgs/", include("organizations.urls")),
     re_path(r"^places/", include("scheduler.place_urls")),
     re_path(r"^admin/", admin.site.urls),
-    re_path(r"^ckeditor/", include("ckeditor_uploader.urls")),
     re_path(r"^i18n/", include("django.conf.urls.i18n")),
     re_path(
         r"^favicon.ico",


### PR DESCRIPTION
When dark mode is enabled in the Django admin, it does not work with the used text field widget (CKEditor), because does not support dark mode properly.

As a quick fix, dark mode is disabled.

fixes #525 