### PR TITLE
Redirect admin users to admin index on 403

### DIFF
--- a/common/admin.py
+++ b/common/admin.py
@@ -4,6 +4,7 @@ from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
@@ -38,9 +39,7 @@ class RedirectOnAdminPermissionDenied403:
             ).format(redirect_path=redirect_path)
             messages.error(
                 request,
-                mark_safe(
-                    f"<strong>{note}</strong><br/>"
-                    f"{error} - {request.method} {request.path}"
-                ),
+                mark_safe(f"<strong>{note}</strong><br/> {error} - ")
+                + escape(f"{request.method} {request.path}"),
             )
             return HttpResponseRedirect(redirect_path)

--- a/common/admin.py
+++ b/common/admin.py
@@ -1,2 +1,46 @@
-# coding=utf-8
-# Register your models here.
+import logging
+
+from django.contrib import messages
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
+
+logger = logging.getLogger(__name__)
+
+
+class RedirectOnAdminPermissionDenied403:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_exception(self, request, exception):
+        admin_index = reverse("admin:index")
+        if (
+            hasattr(request, "user")
+            and getattr(request.user, "is_authenticated", False)
+            and getattr(request.user, "is_staff", False)
+            and request.path != admin_index
+            and request.path.startswith(admin_index)
+            and isinstance(exception, PermissionDenied)
+        ):
+            redirect_path = admin_index
+            error_code = 403
+            error = _("Error {error_code}").format(error_code=error_code)
+            permission_denied = _("Permission denied")
+            error = f"{error}: {permission_denied}"
+            note = _(
+                "You were not allowed to do this and have been redirected to {redirect_path}."  # noqa: E501
+            ).format(redirect_path=redirect_path)
+            messages.error(
+                request,
+                mark_safe(
+                    f"<strong>{note}</strong><br/>"
+                    f"{error} - {request.method} {request.path}"
+                ),
+            )
+            return HttpResponseRedirect(redirect_path)

--- a/common/admin.py
+++ b/common/admin.py
@@ -35,7 +35,7 @@ class RedirectOnAdminPermissionDenied403:
             permission_denied = _("Permission denied")
             error = f"{error}: {permission_denied}"
             note = _(
-                "You were not allowed to do this and have been redirected to {redirect_path}."  # noqa: E501
+                "You are not allowed to do this and have been redirected to {redirect_path}."  # noqa: E501
             ).format(redirect_path=redirect_path)
             messages.error(
                 request,

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -137,7 +137,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2022-03-15 17:56+0000\n"
 "Last-Translator: Christoph Meißner\n"
 "Language-Team: Arabic (http://www.transifex.com/coders4help/volunteer-planner/language/ar/)\n"
@@ -128,6 +128,17 @@ msgstr "مسح الحساب"
 
 msgid "Your user account has been deleted."
 msgstr "لقد تم مسح حسابك"
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgstr ""
 
 msgid "additional CSS"
 msgstr ""

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2022-03-15 17:56+0000\n"
 "Last-Translator: Christoph Meißner\n"
 "Language-Team: Bulgarian (http://www.transifex.com/coders4help/volunteer-planner/language/bg/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: trendspotter <jirka.p@volny.cz>, 2019,2022\n"
 "Language-Team: Czech (http://www.transifex.com/coders4help/volunteer-planner/language/cs/)\n"
@@ -127,6 +127,17 @@ msgstr "Smazat účet"
 
 msgid "Your user account has been deleted."
 msgstr "Váš uživatelský účet byl smazán."
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgstr ""
 
 msgid "additional CSS"
 msgstr "další CSS"

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -136,7 +136,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -134,7 +134,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2017-09-22 15:35+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Danish (http://www.transifex.com/coders4help/volunteer-planner/language/da/)\n"
@@ -124,6 +124,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -148,7 +148,7 @@ msgid "Permission denied"
 msgstr "Keine Berechtigung"
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr "Du kannst diese Aktion nicht ausführen und wurdest stattdessen nach {redirect_path} umgeleitet."
 
 msgid "additional CSS"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Christoph Meißner, 2015,2022\n"
 "Language-Team: German (http://www.transifex.com/coders4help/volunteer-planner/language/de/)\n"
@@ -139,6 +139,17 @@ msgstr "Benutzerkonto löschen"
 
 msgid "Your user account has been deleted."
 msgstr "Dein Benutzerkonto wurde gelöscht."
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr "Fehler {error_code}"
+
+msgid "Permission denied"
+msgstr "Keine Berechtigung"
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgstr "Du kannst diese Aktion nicht ausführen und wurdest stattdessen nach {redirect_path} umgeleitet."
 
 msgid "additional CSS"
 msgstr "zusätzliches CSS"

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Greek (http://www.transifex.com/coders4help/volunteer-planner/language/el/)\n"
@@ -128,6 +128,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -138,7 +138,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2015-10-04 21:53+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: English (http://www.transifex.com/coders4help/volunteer-planner/language/en/)\n"
@@ -120,6 +120,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -130,7 +130,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -137,7 +137,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-04-13 17:27+0000\n"
 "Last-Translator: Antonio Mireles <antonio@mirelesindependent.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/coders4help/volunteer-planner/language/es/)\n"
@@ -128,6 +128,17 @@ msgstr "Eliminar Cuenta"
 
 msgid "Your user account has been deleted."
 msgstr "Tu cuenta de usuario ha sido eliminada."
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgstr ""
 
 msgid "additional CSS"
 msgstr "CSS adicional"

--- a/locale/es_MX/LC_MESSAGES/django.po
+++ b/locale/es_MX/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/coders4help/volunteer-planner/language/es_MX/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/es_MX/LC_MESSAGES/django.po
+++ b/locale/es_MX/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Persian (http://www.transifex.com/coders4help/volunteer-planner/language/fa/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -139,7 +139,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-12-08 20:50+0000\n"
 "Last-Translator: Dolfeus <dolfeus@sfr.fr>\n"
 "Language-Team: French (http://www.transifex.com/coders4help/volunteer-planner/language/fr/)\n"
@@ -130,6 +130,17 @@ msgstr "Supprimer le compte"
 
 msgid "Your user account has been deleted."
 msgstr "Votre compte a été supprimé"
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgstr ""
 
 msgid "additional CSS"
 msgstr "CSS supplémentaire"

--- a/locale/hr/LC_MESSAGES/django.po
+++ b/locale/hr/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Croatian (http://www.transifex.com/coders4help/volunteer-planner/language/hr/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/hr/LC_MESSAGES/django.po
+++ b/locale/hr/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -143,7 +143,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/coders4help/volunteer-planner/language/hu/)\n"
@@ -133,6 +133,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/hy/LC_MESSAGES/django.po
+++ b/locale/hy/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/hy/LC_MESSAGES/django.po
+++ b/locale/hy/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Armenian (http://www.transifex.com/coders4help/volunteer-planner/language/hy/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Italian (http://www.transifex.com/coders4help/volunteer-planner/language/it/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/coders4help/volunteer-planner/language/nl/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Norwegian (http://www.transifex.com/coders4help/volunteer-planner/language/no/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -137,7 +137,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2017-09-22 15:29+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Polish (http://www.transifex.com/coders4help/volunteer-planner/language/pl/)\n"
@@ -127,6 +127,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/coders4help/volunteer-planner/language/pt/)\n"
@@ -128,6 +128,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -138,7 +138,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/coders4help/volunteer-planner/language/pt_BR/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Romanian (http://www.transifex.com/coders4help/volunteer-planner/language/ro/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2022-03-10 13:42+0000\n"
 "Last-Translator: Anna Dunn\n"
 "Language-Team: Russian (http://www.transifex.com/coders4help/volunteer-planner/language/ru/)\n"
@@ -128,6 +128,17 @@ msgstr "Удалить аккаунт"
 
 msgid "Your user account has been deleted."
 msgstr "Ваш аккаунт был удален."
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgstr ""
 
 msgid "additional CSS"
 msgstr "дополнительный CSS"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -137,7 +137,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Slovak (http://www.transifex.com/coders4help/volunteer-planner/language/sk/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Slovenian (http://www.transifex.com/coders4help/volunteer-planner/language/sl/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/sq/LC_MESSAGES/django.po
+++ b/locale/sq/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Albanian (http://www.transifex.com/coders4help/volunteer-planner/language/sq/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/sq/LC_MESSAGES/django.po
+++ b/locale/sq/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/sr_RS/LC_MESSAGES/django.po
+++ b/locale/sr_RS/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/sr_RS/LC_MESSAGES/django.po
+++ b/locale/sr_RS/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Serbian (Serbia) (http://www.transifex.com/coders4help/volunteer-planner/language/sr_RS/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/coders4help/volunteer-planner/language/sv/)\n"
@@ -130,6 +130,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -140,7 +140,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -134,7 +134,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2016-01-29 08:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/coders4help/volunteer-planner/language/tr/)\n"
@@ -124,6 +124,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/tr_TR/LC_MESSAGES/django.po
+++ b/locale/tr_TR/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/coders4help/volunteer-planner/language/tr_TR/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/tr_TR/LC_MESSAGES/django.po
+++ b/locale/tr_TR/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -134,7 +134,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Anna Dunn, 2022\n"
 "Language-Team: Ukrainian (http://www.transifex.com/coders4help/volunteer-planner/language/uk/)\n"
@@ -125,6 +125,17 @@ msgstr "Видалити обліковий запис"
 
 msgid "Your user account has been deleted."
 msgstr "Ваш обліковий запис користувача було видалено."
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgstr ""
 
 msgid "additional CSS"
 msgstr ""

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: volunteer-planner.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-30 10:51+0200\n"
+"POT-Creation-Date: 2022-03-30 18:28+0200\n"
 "PO-Revision-Date: 2015-09-24 12:23+0000\n"
 "Last-Translator: Dorian Cantzen <cantzen@googlemail.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/coders4help/volunteer-planner/language/zh_CN/)\n"
@@ -123,6 +123,17 @@ msgid "Delete Account"
 msgstr ""
 
 msgid "Your user account has been deleted."
+msgstr ""
+
+#, python-brace-format
+msgid "Error {error_code}"
+msgstr ""
+
+msgid "Permission denied"
+msgstr ""
+
+#, python-brace-format
+msgid "You were not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgid "Permission denied"
 msgstr ""
 
 #, python-brace-format
-msgid "You were not allowed to do this and have been redirected to {redirect_path}."
+msgid "You are not allowed to do this and have been redirected to {redirect_path}."
 msgstr ""
 
 msgid "additional CSS"

--- a/volunteer_planner/settings/base.py
+++ b/volunteer_planner/settings/base.py
@@ -76,6 +76,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "common.admin.RedirectOnAdminPermissionDenied403",
 ]
 
 AUTHENTICATION_BACKENDS = [


### PR DESCRIPTION
Adds a middleware to catch any 403 exception for logged in users in the `admin` backoffice and redirects them to the admin index page with a kinda nice-ish message.

![Bildschirmfoto 2022-03-30 um 18 36 52](https://user-images.githubusercontent.com/150454/160886853-c599f2fd-f580-47e6-af7d-f782577d5924.png)

fixes #527