### PR TITLE
Fix bug in ShiftTemplateManager

### DIFF
--- a/scheduletemplates/managers.py
+++ b/scheduletemplates/managers.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from django.db import models
+from django.db.models import F
 
 
 class ShiftTemplateManager(models.Manager):
@@ -16,8 +17,8 @@ class ShiftTemplateManager(models.Manager):
 
         qs = qs.order_by(
             "schedule_template",
-            "task",
-            "workplace",
+            F("task__priority").desc(nulls_last=True),
+            F("workplace__priority").desc(nulls_last=True),
             "starting_time",
             "-days",
             "-ending_time",


### PR DESCRIPTION
Not sure why, but applying `order_by` on the manager's queryset seems to fail, when it tries to order by a field (ie. task or workplace) which is a FK to a model that contains a F-Combinable in its `ordering` property in its Meta object. I guess we might have found a bug in Django.

fixes #541