### PR TITLE
Adapt templates to `translate` and `blocktranslate`

### DIFF
--- a/accounts/templates/shift_list.html
+++ b/accounts/templates/shift_list.html
@@ -9,60 +9,60 @@
 
     <ul class="list-group">
         {% if shifts_today.count > 0  %}
-            {% trans 'My shifts today:' %}
+            {% translate 'My shifts today:' %}
         {% else %}
-            {% trans 'No shifts today.' %}
+            {% translate 'No shifts today.' %}
         {% endif %}
 
         {% for shifts in shifts_today %}
             <li class="list-group-item list-group-item-info">{{ shifts.shift }}
-                <a href="{{shifts.shift.get_absolute_url}}/direct/" class="btn btn-default">{% trans 'Show this work shift' %}</a>
+                <a href="{{shifts.shift.get_absolute_url}}/direct/" class="btn btn-default">{% translate 'Show this work shift' %}</a>
             </li>
         {% endfor %}
     </ul>
 
     <ul class="list-group">
         {% if shifts_tomorrow.count > 0  %}
-            {% trans 'My shifts tomorrow:' %}
+            {% translate 'My shifts tomorrow:' %}
         {% else %}
-            {% trans 'No shifts tomorrow.' %}
+            {% translate 'No shifts tomorrow.' %}
         {% endif %}
 
         {% for shifts in shifts_tomorrow %}
             <li class="list-group-item list-group-item-info">{{ shifts.shift }}
-                <a href="{{shifts.shift.get_absolute_url}}/direct/" class="btn btn-default">{% trans 'Show this work shift' %}</a>
+                <a href="{{shifts.shift.get_absolute_url}}/direct/" class="btn btn-default">{% translate 'Show this work shift' %}</a>
             </li>
         {% endfor %}
     </ul>
 
     <ul class="list-group">
         {% if shifts_day_after_tomorrow.count > 0  %}
-            {% trans 'My shifts the day after tomorrow:' %}
+            {% translate 'My shifts the day after tomorrow:' %}
         {% else %}
-            {% trans 'No shifts the day after tomorrow.' %}
+            {% translate 'No shifts the day after tomorrow.' %}
         {% endif %}
 
         {% for shifts in shifts_day_after_tomorrow %}
             <li class="list-group-item list-group-item-info">{{ shifts.shift }}
-                <a href="{{shifts.shift.get_absolute_url}}/direct/" class="btn btn-default">{% trans 'Show this work shift' %}</a>
+                <a href="{{shifts.shift.get_absolute_url}}/direct/" class="btn btn-default">{% translate 'Show this work shift' %}</a>
             </li>
         {% endfor %}
     </ul>
 
     <ul class="list-group">
         {% if shifts_further_future.count > 0  %}
-            {% trans 'Further shifts:' %}
+            {% translate 'Further shifts:' %}
         {% else %}
-            {% trans 'No further shifts.' %}
+            {% translate 'No further shifts.' %}
         {% endif %}
 
         {% for shifts in shifts_further_future %}
             <li class="list-group-item list-group-item-info">{{ shifts.shift }}
-                <a href="{{shifts.shift.get_absolute_url}}/direct/" class="btn btn-default">{% trans 'Show this work shift' %}</a>
+                <a href="{{shifts.shift.get_absolute_url}}/direct/" class="btn btn-default">{% translate 'Show this work shift' %}</a>
             </li>
 
         {% endfor %}
     </ul>
-    <a href="{% url 'shift_list_done' %}" class="btn btn-default">{% trans 'Show my work shifts in the past' %}</a>
+    <a href="{% url 'shift_list_done' %}" class="btn btn-default">{% translate 'Show my work shifts in the past' %}</a>
 </div>
 {% endblock %}

--- a/accounts/templates/shift_list_done.html
+++ b/accounts/templates/shift_list_done.html
@@ -9,15 +9,15 @@
 
     <ul class="list-group">
         {% if shifts_past.count > 0  %}
-            {% trans 'My work shifts in the past:' %}
+            {% translate 'My work shifts in the past:' %}
         {% else %}
-            {% trans 'No work shifts in the past days yet.' %}
+            {% translate 'No work shifts in the past days yet.' %}
         {% endif %}
 
         {% for shifts in shifts_past %}
             <li class="list-group-item list-group-item-info">{{ shifts.shift }}</li>
         {% endfor %}
     </ul>
-    <a href="{% url 'shift_list_active' %}" class="btn btn-default">{% trans 'Show my work shifts in the future' %}</a>
+    <a href="{% url 'shift_list_active' %}" class="btn btn-default">{% translate 'Show my work shifts in the future' %}</a>
 </div>
 {% endblock %}

--- a/accounts/templates/user_account_delete.html
+++ b/accounts/templates/user_account_delete.html
@@ -7,15 +7,15 @@
 {% block content %}
     <div class="col-md-8 col-md-offset-2">
          <ul class="list-group">
-             <li class="list-group-item list-group-item-info">{% trans 'Username' %}: {{ user.username }}</li>
-             <li class="list-group-item list-group-item-info">{% trans 'First name' %}: {{ user.first_name }}</li>
-             <li class="list-group-item list-group-item-info">{% trans 'Last name' %}: {{ user.last_name }}</li>
-             <li class="list-group-item list-group-item-info">{% trans 'Email' %}: {{ user.email }}</li>
+             <li class="list-group-item list-group-item-info">{% translate 'Username' %}: {{ user.username }}</li>
+             <li class="list-group-item list-group-item-info">{% translate 'First name' %}: {{ user.first_name }}</li>
+             <li class="list-group-item list-group-item-info">{% translate 'Last name' %}: {{ user.last_name }}</li>
+             <li class="list-group-item list-group-item-info">{% translate 'Email' %}: {{ user.email }}</li>
          </ul>
-        {% trans 'If you delete your account, this information will be anonymized, and its not possible for you to log into Volunteer-Planner anymore.' %}
-        {% trans 'Its not possible to recover this information. If you want to work as volunteer again, you will have to create a new account.' %}
+        {% translate 'If you delete your account, this information will be anonymized, and its not possible for you to log into Volunteer-Planner anymore.' %}
+        {% translate 'Its not possible to recover this information. If you want to work as volunteer again, you will have to create a new account.' %}
         <div>
-            <a href="{% url 'account_delete_final' %}" class="btn btn-danger">{% trans 'Delete Account (no additional warning)' %}</a>
+            <a href="{% url 'account_delete_final' %}" class="btn btn-danger">{% translate 'Delete Account (no additional warning)' %}</a>
         </div>
     </div>
 {% endblock %}

--- a/accounts/templates/user_account_edit.html
+++ b/accounts/templates/user_account_edit.html
@@ -9,7 +9,7 @@
     <form action="." method="POST">
         {% csrf_token %}
         {{ form.as_p }}
-        <input class="button" type="submit" value="{% trans 'Save' %}">
+        <input class="button" type="submit" value="{% translate 'Save' %}">
     </form>
 </div>
 {% endblock %}

--- a/accounts/templates/user_detail.html
+++ b/accounts/templates/user_detail.html
@@ -7,14 +7,14 @@
 {% block content %}
 <div class="col-md-8 col-md-offset-2">
     <ul class="list-group">
-        <li class="list-group-item list-group-item-info">{% trans 'Username' %}: {{ user.username }}</li>
-        <li class="list-group-item list-group-item-info">{% trans 'First name' %}: {{ user.first_name }}</li>
-        <li class="list-group-item list-group-item-info">{% trans 'Last name' %}: {{ user.last_name }}</li>
-        <li class="list-group-item list-group-item-info">{% trans 'Email' %}: {{ user.email }}</li>
+        <li class="list-group-item list-group-item-info">{% translate 'Username' %}: {{ user.username }}</li>
+        <li class="list-group-item list-group-item-info">{% translate 'First name' %}: {{ user.first_name }}</li>
+        <li class="list-group-item list-group-item-info">{% translate 'Last name' %}: {{ user.last_name }}</li>
+        <li class="list-group-item list-group-item-info">{% translate 'Email' %}: {{ user.email }}</li>
     </ul>
     <div>
-        <a href="{% url 'account_edit' %}" class="btn btn-default">{% trans 'Edit Account' %}</a>
-        <a href="{% url 'account_delete' %}" class="btn btn-danger">{% trans 'Delete Account' %}</a>
+        <a href="{% url 'account_edit' %}" class="btn btn-default">{% translate 'Edit Account' %}</a>
+        <a href="{% url 'account_delete' %}" class="btn btn-danger">{% translate 'Delete Account' %}</a>
     </div>
 </div>
 {% endblock %}

--- a/accounts/templates/user_detail_deleted.html
+++ b/accounts/templates/user_detail_deleted.html
@@ -3,6 +3,6 @@
 
 {% block content %}
 <div class="col-md-8 col-md-offset-2">
-    {% trans 'Your user account has been deleted.' %}
+    {% translate 'Your user account has been deleted.' %}
 </div>
 {% endblock %}

--- a/content/templates/flatpages/additional_flat_page_style_inline.html
+++ b/content/templates/flatpages/additional_flat_page_style_inline.html
@@ -9,7 +9,7 @@
              id="{{ inline_admin_formset.formset.prefix }}-
                      {% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
             {% if inline_admin_form.show_url %}
-                <a href="{{ inline_admin_form.absolute_url }}">{% trans "View on site" %}</a>{% endif %}
+                <a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
             {% if inline_admin_formset.formset.can_delete and inline_admin_form.original %}
                 <span class="delete">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</span>{% endif %}
             </h3>
@@ -29,8 +29,8 @@
         $("#{{ inline_admin_formset.formset.prefix }}-group .inline-related").stackedFormset({
             prefix: '{{ inline_admin_formset.formset.prefix }}',
             adminStaticPrefix: '{% static "admin/" %}',
-            deleteText: "{% trans "Remove" %}",
-            addText: "{% blocktrans with verbose_name=inline_admin_formset.opts.verbose_name|capfirst %}Add another {{ verbose_name }}{% endblocktrans %}"
+            deleteText: "{% translate "Remove" %}",
+            addText: "{% blocktranslate with verbose_name=inline_admin_formset.opts.verbose_name|capfirst %}Add another {{ verbose_name }}{% endblocktranslate %}"
         });
     })(django.jQuery);
 </script>

--- a/content/templates/flatpages/default.html
+++ b/content/templates/flatpages/default.html
@@ -20,7 +20,7 @@
 
     {% if perms.flatpages.can_change_page %}
         <hr/>
-        <a href="{% url 'admin:flatpages_flatpage_change' flatpage.id %}">{% trans "Edit this page" %}</a>
+        <a href="{% url 'admin:flatpages_flatpage_change' flatpage.id %}">{% translate "Edit this page" %}</a>
     {% endif %}
 
 {% endblock %}

--- a/non_logged_in_area/templates/404.html
+++ b/non_logged_in_area/templates/404.html
@@ -5,9 +5,9 @@
 {% block content %}
     <div class="container">
         <div class="row">
-		<h2>{% trans "Page not found" %}</h2>
+		<h2>{% translate "Page not found" %}</h2>
 		<pre>{{ request_path }}</pre>
-		<p>{% trans "We're sorry, but the requested page could not be found." %}</p>
+		<p>{% translate "We're sorry, but the requested page could not be found." %}</p>
         </div>
     </div>
 {% endblock %}

--- a/non_logged_in_area/templates/500.html
+++ b/non_logged_in_area/templates/500.html
@@ -1,15 +1,15 @@
 {% extends "base_non_logged_in.html" %}
 {% load i18n %}
 
-{% block title %} Volunteer Planner - {% trans "server error" as server_error_title %}{{ server_error_title|title }}{% endblock %}
+{% block title %} Volunteer Planner - {% translate "server error" as server_error_title %}{{ server_error_title|title }}{% endblock %}
 {% block content %}
     <div class="container">
         <div class="row">
-		<h1>{% trans "Server Error <em>(500)</em>" %}</h1>
+		<h1>{% translate "Server Error <em>(500)</em>" %}</h1>
 		<p>
-		{% blocktrans trimmed %}
+		{% blocktranslate trimmed %}
 			There's been an error. It should be fixed shortly. Thanks for your patience.
-		{% endblocktrans %}
+		{% endblocktranslate %}
 		</p>
         </div>
     </div>

--- a/non_logged_in_area/templates/base_non_logged_in.html
+++ b/non_logged_in_area/templates/base_non_logged_in.html
@@ -54,10 +54,10 @@
 		{% include "partials/switch_language.html" with nav_item_tag="span" %}
 
         <a href="{% url 'auth_login' %}" class="btn btn-secondary">
-            {% trans "Login" %}
+            {% translate "Login" %}
                 </a>
         <a href="{% url 'registration_register' %}" class="btn btn-primary">
-            {% trans "Start helping" %}
+            {% translate "Start helping" %}
                 </a>
     </div>
 </nav>
@@ -84,25 +84,25 @@
             <div id="footer-nav">
                 <ul>
                      <li>
-                        <a href="{% url 'home' %}">{% trans "Main page" %}</a>
+                        <a href="{% url 'home' %}">{% translate "Main page" %}</a>
                     </li>
                     <li>
-                        <a href="/impressum/">{% trans "Imprint"%}</a>
+                        <a href="/impressum/">{% translate "Imprint"%}</a>
                     </li>
                     <li>
-                        <a href="/about/">{% trans "About"%}</a>
+                        <a href="/about/">{% translate "About"%}</a>
                     </li>
                     <li>
-                        <a href="/unterstuetzer/">{% trans "Supporter"%}</a>
+                        <a href="/unterstuetzer/">{% translate "Supporter"%}</a>
                     </li>
                     <li>
-                        <a href="/presse/">{% trans "Press"%}</a>
+                        <a href="/presse/">{% translate "Press"%}</a>
                     </li>
                     <li>
-                        <a href="/kontakt/">{% trans "Contact" %}</a>
+                        <a href="/kontakt/">{% translate "Contact" %}</a>
                     </li>
                     <li>
-                        <a href="/faq/">{% trans "FAQ" %}</a>
+                        <a href="/faq/">{% translate "FAQ" %}</a>
                     </li>
                     <li>
                         <a href="https://github.com/coders4help/volunteer_planner" target="_blank">

--- a/non_logged_in_area/templates/home.html
+++ b/non_logged_in_area/templates/home.html
@@ -22,16 +22,16 @@
 
         <div class="col-md-4 ">
             <a id="help-cta" href="{% url 'registration_register' %}">
-                <h2>{% trans "I want to help!" %}</h2>
+                <h2>{% translate "I want to help!" %}</h2>
                 <hr/>
-                <p>{% trans "Register and see where you can help" %}</p>
+                <p>{% translate "Register and see where you can help" %}</p>
             </a><!-- // #about -->
         </div>
         <div class="col-md-4">
             <a href="{% url  "shelter_info" %}" id="need-cta">
-                <h2>{% trans "Organize volunteers!" %}</h2>
+                <h2>{% translate "Organize volunteers!" %}</h2>
                 <hr/>
-                <p>{% trans "Register a shelter and organize volunteers" %}</p>
+                <p>{% translate "Register a shelter and organize volunteers" %}</p>
             </a>
         </div>
         <div class="col-md-4">
@@ -44,21 +44,21 @@
                         {{ volunteer_stats.facility_count|intcomma }}
                     </span>
                     <br/>
-                    {% trans "Places to help" %}
+                    {% translate "Places to help" %}
 
                     <hr/>
                     <span class="fact-amount">
                         {{ volunteer_stats.volunteer_count|intcomma }}
                     </span>
                     <br/>
-                    {% trans "Registered Volunteers" %}
+                    {% translate "Registered Volunteers" %}
                     <hr/>
 
                     <span class="fact-amount">
                         {{ volunteer_stats.volunteer_hours|intcomma }}
                     </span>
                     <br/>
-                    {% trans "Worked Hours" %}
+                    {% translate "Worked Hours" %}
 
                 {% endcache %}
             </div>
@@ -70,23 +70,23 @@
     <div class="row">
 
         <div class="col-md-8">
-            <h2>{% trans "What is it all about?" %}</h2>
+            <h2>{% translate "What is it all about?" %}</h2>
 
             <p>
-                {% blocktrans trimmed %}
+                {% blocktranslate trimmed %}
                     You are a volunteer and want to help refugees?
                     Volunteer-Planner.org shows you where, when and how
                     to help directly in the field.
-                {% endblocktrans %}
+                {% endblocktranslate %}
             </p>
 
 
-            {% blocktrans trimmed %}
+            {% blocktranslate trimmed %}
                 <p>This platform is non-commercial and ads-free. An
                     international team of field workers, programmers, project
                     managers and designers are volunteering for this project and
                     bring in their professional experience to make a difference.</p>
-            {% endblocktrans %}
+            {% endblocktranslate %}
 
         </div>
 
@@ -94,7 +94,7 @@
 
         <div class="col-md-4">
             <div class="facts facts-less-padding">
-                <h2>{% trans "You can help at these locations:" %}</h2>
+                <h2>{% translate "You can help at these locations:" %}</h2>
                 {% if facilities_by_area %}
                     {% for facility_in_area in facilities_by_area %}
                         {% comment %}
@@ -111,7 +111,7 @@
                         </p>
                     {% endfor %}
                 {% else %}
-                    {% trans "There are currently no places in need of help." %}
+                    {% translate "There are currently no places in need of help." %}
                 {% endif %}
             </div>
         </div>

--- a/non_logged_in_area/templates/privacy_policy.html
+++ b/non_logged_in_area/templates/privacy_policy.html
@@ -3,201 +3,201 @@
 
 {% block content %}
 
-    <h2>{% trans "Privacy Policy" %}</h2>
+    <h2>{% translate "Privacy Policy" %}</h2>
 
     <div class="card card-block">
         <h4 class="card-title">
-            {% blocktrans trimmed context "Privacy Policy Sec1" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec1" %}
                 Scope
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h4>
 
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec1 P1" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec1 P1" %}
             This privacy policy informs the user of the collection and use of personal data on this website (herein after "the service") by the service provider, the Benefit e.V. (Wollankstr. 2, 13187 Berlin).
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec1 P2" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec1 P2" %}
             The legal basis for the privacy policy are the German Data Protection Act (Bundesdatenschutzgesetz, BDSG) and the German Telemedia Act (Telemediengesetz, TMG).
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
 
     <div class="card card-block">
         <h4 class="card-title">
-            {% blocktrans trimmed context "Privacy Policy Sec2" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec2" %}
                 Access data / server log files
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h4>
 
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec2 P1" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec2 P1" %}
                 The service provider (or the provider of his webspace) collects data on every access to the service and stores this access data in so-called server log files. Access data includes the name of the website that is being visited, which files are being accessed, the date and time of access, transfered data, notification of successful access, the type and version number of the user's web browser, the user's operating system, the referrer URL (i.e., the website the user visited previously), the user's IP address, and the name of the user's Internet provider.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec2 P2" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec2 P2" %}
             The service provider uses the server log files for statistical purposes and for the operation, the security, and the enhancement of the provided service only. However, the service provider reserves the right to reassess the log files at any time if specific indications for an illegal use of the service exist.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
 
     <div class="card card-block">
         <h4 class="card-title">
-            {% blocktrans trimmed context "Privacy Policy Sec3" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec3" %}
                 Use of personal data
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h4>
 
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec3 P1" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec3 P1" %}
             Personal data is information which can be used to identify a person, i.e., all data that can be traced back to a specific person. Personal data includes the name, the e-mail address, or the telephone number of a user. Even data on personal preferences, hobbies, memberships, or visited websites counts as personal data.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec3 P2" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec3 P2" %}
             The service provider collects, uses, and shares personal data with third parties only if he is permitted by law to do so or if the user has given his permission.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
 
     <div class="card card-block">
         <h4 class="card-title">
-            {% blocktrans trimmed context "Privacy Policy Sec4" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec4" %}
                 Contact
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h4>
 
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec4 P1" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec4 P1" %}
                 When contacting the service provider (e.g. via e-mail or using a web contact form), the data provided by the user is stored for processing the inquiry and for answering potential follow-up inquiries in the future.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
 
     <div class="card card-block">
         <h4 class="card-title">
-            {% blocktrans trimmed context "Privacy Policy Sec5" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec5" %}
                 Cookies
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h4>
 
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec5 P1" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec5 P1" %}
                 Cookies are small files that are being stored on the user's device (personal computer, smartphone, or the like) with information specific to that device. They can be used for various purposes: Cookies may be used to improve the user experience (e.g. by storing and, hence, "remembering" login credentials). Cookies may also be used to collect statistical data that allows the service provider to analyse the user's usage of the website, aiming to improve the service.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec5 P2" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec5 P2" %}
                 The user can customize the use of cookies. Most web browsers offer settings to restrict or even completely prevent the storing of cookies. However, the service provider notes that such restrictions may have a negative impact on the user experience and the functionality of the website.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec5 P3" with us_url="<a href='http://www.aboutads.info/choices/'>http://www.aboutads.info/choices/</a>" eu_url="<a href='http://www.youronlinechoices.com/uk/your-ad-choices/'>http://www.youronlinechoices.com/uk/your-ad-choices/</a>" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec5 P3" with us_url="<a href='http://www.aboutads.info/choices/'>http://www.aboutads.info/choices/</a>" eu_url="<a href='http://www.youronlinechoices.com/uk/your-ad-choices/'>http://www.youronlinechoices.com/uk/your-ad-choices/</a>" %}
                 The user can manage the use of cookies from many online advertisers by visiting either the US-american website {{ us_url }} or the European website {{ eu_url }}.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
 
     <div class="card card-block">
         <h4 class="card-title">
-            {% blocktrans trimmed context "Privacy Policy Sec6" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec6" %}
                 Registration
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h4>
 
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec6 P1" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec6 P1" %}
                 The data provided by the user during registration allows for the usage of the service. The service provider may inform the user via e-mail about information relevant to the service or the registration, such as information on changes, which the service undergoes, or technical information (see also next section).
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec6 P2" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec6 P2" %}
                 The registration and user profile forms show which data is being collected and stored. They include - but are not limited to - the user's first name, last name, and e-mail address.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
 
     <div class="card card-block">
         <h4 class="card-title">
-            {% blocktrans trimmed context "Privacy Policy Sec7" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec7" %}
             E-mail notifications / Newsletter
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h4>
 
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec7 P1" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec7 P1" %}
             When registering an account with the service, the user gives permission to receive e-mail notifications as well as newsletter e-mails.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec7 P2" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec7 P2" %}
             E-mail notifications inform the user of certain events that relate to the user's use of the service. With the newsletter, the service provider sends the user general information about the provider and his offered service(s).
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec7 P3" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec7 P3" %}
             If the user wishes to revoke his permission to receive e-mails, he needs to delete his user account. 
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
 
     <div class="card card-block">
         <h4 class="card-title">
-            {% blocktrans trimmed context "Privacy Policy Sec8" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec8" %}
                 Google Analytics
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h4>
 
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec8 P1" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec8 P1" %}
             This website uses Google Analytics, a web analytics service provided by Google, Inc. (“Google”). Google Analytics uses “cookies”, which are text files placed on the user's device, to help the website analyze how users use the site. The information generated by the cookie about the user's use of the website will be transmitted to and stored by Google on servers in the United States.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec8 P2" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec8 P2" %}
             In case IP-anonymisation is activated on this website, the user's IP address will be truncated within the area of Member States of the European Union or other parties to the Agreement on the European Economic Area. Only in exceptional cases the whole IP address will be first transfered to a Google server in the USA and truncated there. The IP-anonymisation is active on this website.
-        {% endblocktrans %}
+        {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec8 P3" %} 
+            {% blocktranslate trimmed context "Privacy Policy Sec8 P3" %}
             Google will use this information on behalf of the operator of this website for the purpose of evaluating your use of the website, compiling reports on website activity for website operators and providing them other services relating to website activity and internet usage.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec8 P4" with optout_plugin_url="<a href='http://tools.google.com/dlpage/gaoptout?hl=en'>http://tools.google.com/dlpage/gaoptout?hl=en</a>"%} 
+            {% blocktranslate trimmed context "Privacy Policy Sec8 P4" with optout_plugin_url="<a href='http://tools.google.com/dlpage/gaoptout?hl=en'>http://tools.google.com/dlpage/gaoptout?hl=en</a>"%}
             The IP-address, that the user's browser conveys within the scope of Google Analytics, will not be associated with any other data held by Google. The user may refuse the use of cookies by selecting the appropriate settings on his browser, however it is to be noted that if the user does this he may not be able to use the full functionality of this website. He can also opt-out from being tracked by Google Analytics with effect for the future by downloading and installing Google Analytics Opt-out Browser Addon for his current web browser: {{ optout_plugin_url }}.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
         <p class="card-text">
-            {% trans "click this link" as click %}
-            {% blocktrans trimmed context "Privacy Policy Sec8 P5" with optout_javascript="<a href='javascript:gaOptout()'>"|add:click|add:"</a>"%} 
+            {% translate "click this link" as click %}
+            {% blocktranslate trimmed context "Privacy Policy Sec8 P5" with optout_javascript="<a href='javascript:gaOptout()'>"|add:click|add:"</a>"%}
             As an alternative to the browser Addon or within browsers on mobile devices, the user can {{ optout_javascript }} in order to opt-out from being tracked by Google Analytics within this website in the future (the opt-out applies only for the browser in which the user sets it and within this domain). An opt-out cookie will be stored on the user's device, which means that the user will have to click this link again, if he deletes his cookies.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
 
     <div class="card card-block">
         <h4 class="card-title">
-            {% blocktrans trimmed context "Privacy Policy Sec9" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec9" %}
                 Revocation, Changes, Corrections, and Updates
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h4>
 
         <p class="card-text">
-            {% blocktrans trimmed context "Privacy Policy Sec9 P1" %}
+            {% blocktranslate trimmed context "Privacy Policy Sec9 P1" %}
             The user has the right to be informed upon application and free of charge, which personal data about him has been stored. Additionally, the user can ask for the correction of uncorrect data, as well as for the suspension or even deletion of his personal data as far as there is no legal obligation to retain that data.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
 
     <div class="card card-block">
         <p class="card-text">
             <a href="http://rechtsanwalt-schwenke.de/smmr-buch/datenschutz-muster-generator-fuer-webseiten-blogs-und-social-media/">
-                {% blocktrans trimmed context "Privacy Policy Credit" %}
+                {% blocktranslate trimmed context "Privacy Policy Credit" %}
                     Based on the privacy policy sample of the lawyer Thomas Schwenke - I LAW it
-                {% endblocktrans %}
+                {% endblocktranslate %}
             </a>
         </p>
     </div>

--- a/non_logged_in_area/templates/shelters_need_help.html
+++ b/non_logged_in_area/templates/shelters_need_help.html
@@ -17,62 +17,62 @@
     <div class="col-md-12">
     </div>
     <div class="col-md-6">
-        <h2> {% trans "advantages" %}</h2>
+        <h2> {% translate "advantages" %}</h2>
         <ul class="advantages">
-            <li class="check-icon"> {% trans "save time" %}</li>
-            <li class="check-icon"> {% trans "improve selforganization of the volunteers" %}
+            <li class="check-icon"> {% translate "save time" %}</li>
+            <li class="check-icon"> {% translate "improve selforganization of the volunteers" %}
             </li>
             <li class="check-icon">
-                {% blocktrans %}
+                {% blocktranslate %}
                     volunteers split themselves up more effectively into shifts,
                     temporary shortcuts can be anticipated by helpers themselves more easily
-                {% endblocktrans %}
+                {% endblocktranslate %}
             </li>
             <li class="check-icon">
-                {% blocktrans %}
+                {% blocktranslate %}
                     shift plans can be given to the security personnel
                     or coordinating persons by an auto-mailer
                     every morning
-                {% endblocktrans %}
+                {% endblocktranslate %}
             </li>
             <li class="check-icon">
-                {% blocktrans %}
+                {% blocktranslate %}
                 the more shelters and camps are organized with us, the more volunteers are joining
                     and all facilities will benefit from a common pool of motivated volunteers
-                {% endblocktrans %}
+                {% endblocktranslate %}
             </li>
             <li class="check-icon">
-                 {% trans "for free without costs" %}
+                 {% translate "for free without costs" %}
             </li>
         </ul>
 
     </div>
     <div class="col-md-6">
-        <h2> {% trans "The right help at the right time at the right place" %}</h2>
-                 {% blocktrans %}
+        <h2> {% translate "The right help at the right time at the right place" %}</h2>
+                 {% blocktranslate %}
         <p>Many people want to help! But often it's not so easy to figure out where, when and how one can help.
         volunteer-planner tries to solve this problem! <br>
         </p>
-            {% endblocktrans %}
+            {% endblocktranslate %}
     </div>
 
     <div class="col-md-6">
-        <h2> {% trans "for free, ad free" %}</h2>
-        {% blocktrans %}
+        <h2> {% translate "for free, ad free" %}</h2>
+        {% blocktranslate %}
         <p>  The platform was build by a group of volunteering professionals in the area of software development, project management, design,
         and marketing. The code is open sourced for non-commercial use. Private data (emailaddresses, profile data etc.) will be not given to any third party.</p>
-            {% endblocktrans %}
+            {% endblocktranslate %}
     </div>
     <div class="col-md-12">
         <div class="jumbotron jumbotron-fluid">
             <div class="container">
-                <h1 class="display-3">{% trans "contact us!" %}</h1>
+                <h1 class="display-3">{% translate "contact us!" %}</h1>
 
                 <p class="lead">
-                    {% blocktrans %}
+                    {% blocktranslate %}
                     ...maybe with an attached draft of the shifts you want to see on volunteer-planner. Please write to <a
                             href="mailto:onboarding@volunteer-planner.org">onboarding@volunteer-planner.org</a>
-                    {% endblocktrans %}
+                    {% endblocktranslate %}
                 </p>
             </div>
         </div>

--- a/organizations/templates/emails/membership_approved.txt
+++ b/organizations/templates/emails/membership_approved.txt
@@ -1,11 +1,11 @@
 {% load i18n %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Hello {{ username }},
-{% endblocktrans %}
+{% endblocktranslate %}
 
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Your membership request at {{ facility_name }} was approved. You now may sign up for restricted shifts at this facility.
-{% endblocktrans %}
+{% endblocktranslate %}
 
-{% blocktrans %}Yours,
-the volunteer-planner.org Team{% endblocktrans %}
+{% blocktranslate %}Yours,
+the volunteer-planner.org Team{% endblocktranslate %}

--- a/organizations/templates/facility.html
+++ b/organizations/templates/facility.html
@@ -6,7 +6,7 @@
 
     <ul class="breadcrumb">
         <li>
-            <a href="/helpdesk/">{% trans "Helpdesk" %}</a>
+            <a href="/helpdesk/">{% translate "Helpdesk" %}</a>
         </li>
 
         <li>
@@ -26,7 +26,7 @@
     {% if facility.address_line %}
         <p>
             {{ facility.address_line }}
-            <a target="_blank" rel="noreferrer" href="{{ facility.osm_link }}">→ {% trans "Show on map" %}</a>
+            <a target="_blank" rel="noreferrer" href="{{ facility.osm_link }}">→ {% translate "Show on map" %}</a>
         </p>
     {% endif %}
 
@@ -38,7 +38,7 @@
         <a href="{{ facility.organization.url }}">{{ facility.organization.name }} </a>
     </p>
 
-    <h4>{% trans "Open Shifts" %}</h4>
+    <h4>{% translate "Open Shifts" %}</h4>
     <p>
         {% for shift in facility.shifts %}
             <a href="{{ shift.link }}">{{ shift.date_string }}</a>
@@ -47,7 +47,7 @@
     </p>
 
     {% if facility.news %}
-        <h4>{% trans "News" %}</h4>
+        <h4>{% translate "News" %}</h4>
         {% for news in facility.news %}
             <h5>{{ news.title }}</h5>
             <date><i>{{ news.date }}</i></date>

--- a/organizations/templates/manage_members.html
+++ b/organizations/templates/manage_members.html
@@ -15,7 +15,7 @@
 
                 function onError(content) {
                     if (content.status == 403) {
-                        alert('{% trans "Error" %}\n{% trans "You are not allowed to do this." %}');
+                        alert('{% translate "Error" %}\n{% translate "You are not allowed to do this." %}');
                     }
                 }
 
@@ -40,9 +40,9 @@
         <div class="row">
 
             <h2>
-                {% blocktrans trimmed %}
+                {% blocktranslate trimmed %}
                     Members in {{ facility }}
-                {% endblocktrans %}
+                {% endblocktranslate %}
             </h2>
 
         </div>
@@ -61,16 +61,16 @@
                     <thead>
                     <tr>
                         <th>
-                            {% trans "Username" %}
+                            {% translate "Username" %}
                         </th>
                         <th>
-                            {% trans "Email" %}
+                            {% translate "Email" %}
                         </th>
                         <th>
-                            {% trans "Role" %}
+                            {% translate "Role" %}
                         </th>
                         <th>
-                            {% trans "Actions" %}
+                            {% translate "Actions" %}
                         </th>
                     </tr>
                     </thead>
@@ -95,18 +95,18 @@
                             <td>
                                 {% if membership.status == membership.Status.APPROVED %}
                                     <span data-action="reject" class="fa fa-minus-circle action">
-                                        {% trans "Block" %}
+                                        {% translate "Block" %}
                                     </span>&nbsp;|&nbsp;
                                 {% elif membership.status == membership.Status.PENDING %}
                                     <span data-action="accept" class="fa fa-user-plus action">
-                                        {% trans "Accept" %}
+                                        {% translate "Accept" %}
                                     </span>&nbsp;|&nbsp;
                                     <span data-action="reject" class="fa fa-minus-circle action">
-                                        {% trans "Block" %}
+                                        {% translate "Block" %}
                                     </span>&nbsp;|&nbsp;
                                 {% endif %}
                                 <span data-action="remove" class="fa fa-remove action">
-                                    {% trans "Remove" %}
+                                    {% translate "Remove" %}
                                 </span>
                             </td>
                         </tr>

--- a/organizations/templates/organization.html
+++ b/organizations/templates/organization.html
@@ -6,7 +6,7 @@
 
     <ul class="breadcrumb">
         <li>
-            <a href="/helpdesk/">{% trans "Helpdesk" %}</a>
+            <a href="/helpdesk/">{% translate "Helpdesk" %}</a>
         </li>
 
         <li class="active">
@@ -23,7 +23,7 @@
 
     {{ object.description | safe }}
 
-    <h2>{% trans "Facilities" %}</h2>
+    <h2>{% translate "Facilities" %}</h2>
 
     {% for facility in object.facilities.all %}
         {% include 'partials/compact_facility.html' with facility=facility %}

--- a/organizations/templates/partials/compact_facility.html
+++ b/organizations/templates/partials/compact_facility.html
@@ -16,7 +16,7 @@
         </p>
 
         <p>
-            <a href="{{ facility.get_absolute_url }}">{% trans "Show details" %}</a>
+            <a href="{{ facility.get_absolute_url }}">{% translate "Show details" %}</a>
         </p>
     </div>
 
@@ -24,7 +24,7 @@
     {% regroup facility.open_shifts.all by starting_time.date as shifts_by_day %}
     {% if shifts_by_day %}
         <div class="pull-right">
-            <h4>{% trans "Open Shifts" %}</h4>
+            <h4>{% translate "Open Shifts" %}</h4>
 
             <p>
                 {% for shifts_on_day in shifts_by_day %}

--- a/scheduler/templates/geographic_helpdesk.html
+++ b/scheduler/templates/geographic_helpdesk.html
@@ -66,19 +66,19 @@
                                                     <h5>{{ facility.address_line }}
                                                         <a href="{{ facility.address_line|osm_search }}"
                                                            target="_blank" rel="noreferrer">
-                                                            &rarr; {% trans "Show on map" %}
+                                                            &rarr; {% translate "Show on map" %}
                                                         </a>
                                                     </h5>
                                                 {% endif %}
                                                 <p>{{ facility.description|safe }}</p>
 
                                                 <p>
-                                                    <a href="{{ facility.get_absolute_url }}">{% trans "Show details" %}</a>
+                                                    <a href="{{ facility.get_absolute_url }}">{% translate "Show details" %}</a>
                                                 </p>
                                             </div>
 
                                             <div class="pull-right">
-                                                {% trans "shifts" as shifts_heading context "helpdesk shifts heading" %}
+                                                {% translate "shifts" as shifts_heading context "helpdesk shifts heading" %}
                                                 <h3>
                                                     {{ shifts_heading|title }}
                                                 </h3>
@@ -110,10 +110,10 @@
         </div>
     {% else %}
         <h2>
-            {% blocktrans trimmed with geographical_name=geographical_unit.name %}
+            {% blocktranslate trimmed with geographical_name=geographical_unit.name %}
                 There are no upcoming shifts available for
                 {{ geographical_name }}.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h2>
     {% endif %}
 {% endblock %}

--- a/scheduler/templates/helpdesk.html
+++ b/scheduler/templates/helpdesk.html
@@ -67,11 +67,11 @@
 {% block content %}
 
         <div ng-cloak ng-controller="ShiftWidgetCtrl">
-            <h2>{% trans "You can help in the following facilities" %}</h2>
+            <h2>{% translate "You can help in the following facilities" %}</h2>
             {% verbatim %}
                 <hr>
                 <div ng-show="countries.length > 1">
-                    {% endverbatim %}<span>{% trans "countries" as countries_title %}{{ countries_title|title }}:</span>{% verbatim %}
+                    {% endverbatim %}<span>{% translate "countries" as countries_title %}{{ countries_title|title }}:</span>{% verbatim %}
                     <label class="filter" ng-repeat="country in countries">
                         <input id="filter-{{ country.slug }}" type="checkbox" value="{{ country.name }}"
                             ng-click="toggleCountryAndArea(country.slug)"
@@ -80,7 +80,7 @@
                     </label>
                 </div>
               <div>
-                    {% endverbatim %}<span>{% trans "areas" as area_title %}{{ area_title|title }}:</span>{% verbatim %}
+                    {% endverbatim %}<span>{% translate "areas" as area_title %}{{ area_title|title }}:</span>{% verbatim %}
                     <label class="filter" ng-repeat="area in areas">
                         <input id="filter-{{ area.slug }}" type="checkbox" value="{{ area.name }}"
                             ng-click="toggleCountryAndArea(area.slug)"
@@ -95,7 +95,7 @@
                             <accordion>
                                 <accordion-group panel-class="panel-primary">
                                     <accordion-heading>
-                                        {{ facility.name }} {% endverbatim %}[{% trans "see more" %}]{% verbatim %} <span class="glyphicon glyphicon-triangle-bottom pull-right"></span>
+                                        {{ facility.name }} {% endverbatim %}[{% translate "see more" %}]{% verbatim %} <span class="glyphicon glyphicon-triangle-bottom pull-right"></span>
                                     </accordion-heading>
                                     <div class="col-md-12">
                                         <div class="col-md-8">
@@ -104,9 +104,9 @@
                                                 <a target="_blank" rel="noreferrer" ng-href="{{ facility.osm_link }}">→ Show on map</a>
                                             </h5>
                                             <p ng-bind-html="facility.description"></p>
-                                            <a ng-href="{{ facility.url }}">{% endverbatim %}{% trans "Show details" %}{% verbatim %}</a>
+                                            <a ng-href="{{ facility.url }}">{% endverbatim %}{% translate "Show details" %}{% verbatim %}</a>
 
-                                            <h4 ng-show="facility.news[0]">{% endverbatim %}{% trans "news" as news_title %}{{ news_title|title }}{% verbatim %}</h4>
+                                            <h4 ng-show="facility.news[0]">{% endverbatim %}{% translate "news" as news_title %}{{ news_title|title }}{% verbatim %}</h4>
                                         <div ng-repeat="news in facility.news">
                                             <hr>
                                         <h4>{{ news.title }} </h4>
@@ -115,7 +115,7 @@
                                         </div>
                                         </div>
                                         <div class="col-md-4">
-                                            {% endverbatim %}<h4>{% trans "open shifts" %}</h4>{% verbatim %}
+                                            {% endverbatim %}<h4>{% translate "open shifts" %}</h4>{% verbatim %}
                                             <p>
                                                 <span ng-repeat="shift in facility.shifts">
                                                     <a ng-href="{{ shift.link }}">{{ shift.date_string }}</a>

--- a/scheduler/templates/helpdesk_breadcrumps.html
+++ b/scheduler/templates/helpdesk_breadcrumps.html
@@ -3,7 +3,7 @@
 {% if breadcrumps %}
     <ul class="breadcrumb">
         <li>
-            <a href="/helpdesk/">{% trans "Helpdesk" %}</a>
+            <a href="/helpdesk/">{% translate "Helpdesk" %}</a>
         </li>
 
         {% for breadcrump in breadcrumps.flattened %}

--- a/scheduler/templates/helpdesk_single.html
+++ b/scheduler/templates/helpdesk_single.html
@@ -3,9 +3,9 @@
 {% load i18n vpfilters static memberships %}
 
 {% block title %}
-    {% blocktrans trimmed context "title with facility" with facility_name=facility.name %}
+    {% blocktranslate trimmed context "title with facility" with facility_name=facility.name %}
         Schedule for {{ facility_name }}
-    {% endblocktrans %}
+    {% endblocktranslate %}
 {% endblock %}
 
 {% if facility.timeline_enabled > facility.TimelineViewMode.DISABLED %}
@@ -57,7 +57,7 @@
                                         id: {{ shift.id }},
                                         group: {{ task.id }},
                                         subgroup: '{{ workplace.id|default:"no workplace" }}',
-                                        content: '<a href="#{{ shift.id }}">{{ shift.workplace.name|default:shift.task.name }} ({{ shift.volunteer_count }}/{{ shift.slots }})<br>{% blocktrans trimmed with starting_time=shift.starting_time|date:"H:i" ending_time=shift.ending_time|date:"H:i" %}{{ starting_time }} - {{ ending_time }}{% endblocktrans %}</a>',
+                                        content: '<a href="#{{ shift.id }}">{{ shift.workplace.name|default:shift.task.name }} ({{ shift.volunteer_count }}/{{ shift.slots }})<br>{% blocktranslate trimmed with starting_time=shift.starting_time|date:"H:i" ending_time=shift.ending_time|date:"H:i" %}{{ starting_time }} - {{ ending_time }}{% endblocktranslate %}</a>',
                                         subgroupOrder: '{{ workplace.name }}',
                                         start: "{{ shift.starting_time|date:"c" }}",
                                         end: "{{ shift.ending_time|date:"c" }}"
@@ -141,7 +141,7 @@
 
     <ul class="breadcrumb">
         <li>
-            <a href="/helpdesk/">{% trans "Helpdesk" %}</a>
+            <a href="/helpdesk/">{% translate "Helpdesk" %}</a>
         </li>
 
         <li>
@@ -169,9 +169,9 @@
         </h2>
 
         <h3>
-            {% blocktrans trimmed context "title with date" with schedule_date=schedule_date|date %}
+            {% blocktranslate trimmed context "title with date" with schedule_date=schedule_date|date %}
                 Schedule for {{ schedule_date }}
-            {% endblocktrans %}
+            {% endblocktranslate %}
 
         </h3>
 
@@ -182,7 +182,7 @@
                     href="#timeline"
                     aria-expanded="false"
                     aria-controls="timeline">
-                {% trans "Toggle Timeline" %}
+                {% translate "Toggle Timeline" %}
             </button>
 
             {% if facility.timeline_enabled > facility.TimelineViewMode.DISABLED %}
@@ -234,13 +234,13 @@
                                 <thead>
                                 <tr>
                                     <th>
-                                        {% trans "Link" %}
+                                        {% translate "Link" %}
                                     </th>
                                     <th colspan="2" width="10%">
-                                        {% trans "Time" %}
+                                        {% translate "Time" %}
                                     </th>
                                     <th colspan="3" width="80%">
-                                        {% trans "Helpers" %}
+                                        {% translate "Helpers" %}
                                     </th>
                                     <th colspan="1" width="10%">
 
@@ -251,22 +251,22 @@
                                         <span class="fa fa-link"></span>
                                     </th>
                                     <th width="5%">
-                                        {% trans "Start" %}
+                                        {% translate "Start" %}
                                     </th>
                                     <th width="5%">
-                                        {% trans "End" %}
+                                        {% translate "End" %}
                                     </th>
                                     <th width="5%">
-                                        {% trans "Required" %}
+                                        {% translate "Required" %}
                                     </th>
                                     <th width="15%">
-                                        {% trans "Status" %}
+                                        {% translate "Status" %}
                                     </th>
                                     <th>
-                                        {% trans "Users" %}
+                                        {% translate "Users" %}
                                     </th>
                                     <th width="20%">
-                                        {% trans "You" %}
+                                        {% translate "You" %}
                                     </th>
                                 </tr>
                                 </thead>
@@ -318,18 +318,18 @@
                                         <span style="color:{% if slots_left %}red{% else %}green{% endif %};">
 
                                             {% if slots_left > 0 %}
-                                                {% blocktrans trimmed %}
+                                                {% blocktranslate trimmed %}
                                                     {{ slots_left }} more
-                                                {% endblocktrans %}
+                                                {% endblocktranslate %}
                                             {% else %}
-                                                {% trans "Covered" %}
+                                                {% translate "Covered" %}
                                             {% endif %}
                                         </span>
                                             </td>
 
                                             <td>
                                                 {% if shift.members_only and not user|is_facility_member:shift.facility %}
-                                                    {# <span class="fa fa-lock">&nbsp;{% trans "Members only" %}</span> #}
+                                                    {# <span class="fa fa-lock">&nbsp;{% translate "Members only" %}</span> #}
                                                 {% else %}
                                                     {% for volunteer in shift.helpers.all %}
                                                         {% if volunteer.user == request.user %}
@@ -347,7 +347,7 @@
 
                                             <td>
                                                 {% if is_assigned %}
-                                                    {% trans "Drop out" as dropout_button_label %}
+                                                    {% translate "Drop out" as dropout_button_label %}
 
                                                     <button type="submit"
                                                             name="leave_shift"
@@ -357,7 +357,7 @@
                                                     </button>
 
                                                     {% elif slots_left > 0 %}
-                                                    {% trans "Sign up" as signup_button_label %}
+                                                    {% translate "Sign up" as signup_button_label %}
 
                                                     {% if shift.members_only %}
                                                         {% if user|is_facility_member:shift.facility %}
@@ -368,21 +368,21 @@
                                                                 &nbsp;{{ signup_button_label|title }}
                                                             </button>
                                                         {% elif user|is_membership_pending:shift.facility %}
-                                                            {% trans "Membership pending" as membership_pending_label %}
+                                                            {% translate "Membership pending" as membership_pending_label %}
                                                             <button type="submit"
                                                                     class="btn btn-default fa fa-hourglass disabled"
                                                                     disabled>
                                                                 &nbsp;{{ membership_pending_label|title }}
                                                             </button>
                                                             {% elif user|is_membership_rejected:shift.facility %}
-                                                            {% trans "Membership rejected" as membership_rejected_label %}
+                                                            {% translate "Membership rejected" as membership_rejected_label %}
                                                             <button type="submit"
                                                                     class="btn btn-default fa fa-minus-circle disabled"
                                                                     disabled>
                                                                 &nbsp;{{ membership_rejected_label|title }}
                                                             </button>
                                                         {% else %}
-                                                            {% trans "Become member" as members_only_button_label %}
+                                                            {% translate "Become member" as members_only_button_label %}
                                                             <button type="submit"
                                                                     name="join_shift"
                                                                     value="{{ shift.pk }}"
@@ -403,7 +403,7 @@
                                                     <button type="submit"
                                                             class="btn btn-default fa fa-minus-circle disabled"
                                                             disabled>
-                                                        &nbsp;{% trans "Covered" %}
+                                                        &nbsp;{% translate "Covered" %}
                                                     </button>
                                                 {% endif %}
                                             </td>

--- a/scheduler/templates/shift_cancellation_notification.html
+++ b/scheduler/templates/shift_cancellation_notification.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% blocktrans with shift_title=shift.task.name.strip|safe location=shift.facility.name.strip|safe from_date=shift.starting_time.date|date from_time=shift.starting_time.time to_time=shift.ending_time.time %}
+{% load i18n %}{% blocktranslate with shift_title=shift.task.name.strip|safe location=shift.facility.name.strip|safe from_date=shift.starting_time.date|date from_time=shift.starting_time.time to_time=shift.ending_time.time %}
 Hello,
 
 we're sorry, but we had to cancel the following shift at request of the organizer:
@@ -11,4 +11,4 @@ This is an automatically generated e-mail. If you have any questions, please con
 Yours,
 
 the volunteer-planner.org team
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/scheduler/templates/shift_details.html
+++ b/scheduler/templates/shift_details.html
@@ -21,16 +21,16 @@
 {% load i18n vpfilters static memberships %}
 
 {% block title %}
-    {% blocktrans trimmed context "title with facility" with facility_name=facility.name %}
+    {% blocktranslate trimmed context "title with facility" with facility_name=facility.name %}
         Schedule for {{ facility_name }}
-    {% endblocktrans %}
+    {% endblocktranslate %}
 {% endblock %}
 
 {% block helpdesk_content %}
 
     <ul class="breadcrumb">
         <li>
-            <a href="/helpdesk/">{% trans "Helpdesk" %}</a>
+            <a href="/helpdesk/">{% translate "Helpdesk" %}</a>
         </li>
 
         <li>
@@ -92,7 +92,7 @@
     {% with slots_left=shift.volunteer_count|subtract:shift.slots is_assigned=shift.helpers.all|contains:user.account %}
 
         {% if is_assigned %}
-            {% trans "Drop out" as dropout_button_label %}
+            {% translate "Drop out" as dropout_button_label %}
 
             <button type="submit"
                     name="leave_shift"
@@ -102,10 +102,10 @@
             </button>
 
             {% elif slots_left %}
-            {% trans "Sign up" as signup_button_label %}
+            {% translate "Sign up" as signup_button_label %}
 
             {% if shift.members_only %}
-                {% trans "Members only" as members_only_button_label %}
+                {% translate "Members only" as members_only_button_label %}
                 {% if user|is_facility_member:shift.facility %}
                     <button type="submit"
                             name="join_shift"
@@ -131,7 +131,7 @@
                 </button>
             {% endif %}
         {% else %}
-            {% trans "Covered" %}
+            {% translate "Covered" %}
         {% endif %}
     {% endwith %}
     <p class="fa fa-group">

--- a/scheduler/templates/shift_modification_notification.html
+++ b/scheduler/templates/shift_modification_notification.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% blocktrans with shift_title=shift.task.name.strip|safe location=shift.facility.name.strip|safe from_date=shift.starting_time.date|date from_time=shift.starting_time.time to_time=shift.ending_time.time old_from_date=old.starting_time.date|date old_from_time=old.starting_time.time old_to_time=old.ending_time.time %}
+{% load i18n %}{% blocktranslate with shift_title=shift.task.name.strip|safe location=shift.facility.name.strip|safe from_date=shift.starting_time.date|date from_time=shift.starting_time.time to_time=shift.ending_time.time old_from_date=old.starting_time.date|date old_from_time=old.starting_time.time old_to_time=old.ending_time.time %}
 Hello,
 
 we're sorry, but we had to change the times of the following shift at request of the organizer:
@@ -17,4 +17,4 @@ This is an automatically generated e-mail. If you have any questions, please con
 Yours,
 
 the volunteer-planner.org team
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/scheduletemplates/templates/admin/scheduletemplates/apply_template.html
+++ b/scheduletemplates/templates/admin/scheduletemplates/apply_template.html
@@ -28,7 +28,7 @@
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
-        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+        <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
         &rsaquo; <a
             href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
         &rsaquo;
@@ -36,37 +36,37 @@
         &rsaquo;
         <a href="{% url opts|admin_urlname:'change' schedule_template.pk|admin_urlquote %}">{{ schedule_template }}</a>
         &rsaquo;
-        {% trans "Apply Template" %}
+        {% translate "Apply Template" %}
     </div>
 {% endblock %}
 
 {% block content %}
     <div id="content-main">
-        <h2>{% trans "Apply Template" %} {{ schedule_template }}</h2>
+        <h2>{% translate "Apply Template" %} {{ schedule_template }}</h2>
 
         <form method="post">
             {% csrf_token %}
 
-            {% trans "no workplace" as no_workplace %}
-            {% trans "apply" as apply_trans %}
-            {% trans "number of needed volunteers" as num_trans %}
-            {% trans "task" as task_trans %}
-            {% trans "workplace" as workplace_trans %}
-            {% trans "starting time" as starting_trans %}
-            {% trans "ending time" as ending_trans %}
-            {% trans "members only" as members_only_trans %}
+            {% translate "no workplace" as no_workplace %}
+            {% translate "apply" as apply_trans %}
+            {% translate "number of needed volunteers" as num_trans %}
+            {% translate "task" as task_trans %}
+            {% translate "workplace" as workplace_trans %}
+            {% translate "starting time" as starting_trans %}
+            {% translate "ending time" as ending_trans %}
+            {% translate "members only" as members_only_trans %}
             {% regroup shift_templates by task as shifts_by_task %}
 
-            <h3>{% trans "Select a date" %} </h3>
+            <h3>{% translate "Select a date" %} </h3>
 
             <div>
                 {{ apply_form.apply_for_date }}
 
-                <input type="submit" value="{% trans "Continue" %}"
+                <input type="submit" value="{% translate "Continue" %}"
                        class="default" name="preview" style="float: initial;">
             </div>
 
-            <h3>{% trans "Select shift templates" %}</h3>
+            <h3>{% translate "Select shift templates" %}</h3>
 
             <div>
 
@@ -121,7 +121,7 @@
                 </table>
             </div>
             <div class="submit-row">
-                <input type="submit" value="{% trans "Continue" %}"
+                <input type="submit" value="{% translate "Continue" %}"
                        class="default" name="preview">
             </div>
         </form>

--- a/scheduletemplates/templates/admin/scheduletemplates/apply_template_confirm.html
+++ b/scheduletemplates/templates/admin/scheduletemplates/apply_template_confirm.html
@@ -3,7 +3,7 @@
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
-        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+        <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
         &rsaquo; <a
             href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
         &rsaquo;
@@ -11,7 +11,7 @@
         &rsaquo;
         <a href="{% url opts|admin_urlname:'change' schedule_template.pk|admin_urlquote %}">{{ schedule_template }}</a>
         &rsaquo;
-        {% trans "Apply Template" %}
+        {% translate "Apply Template" %}
     </div>
 {% endblock %}
 
@@ -19,7 +19,7 @@
     <div id="content-main">
 
     <h2>
-        {% trans "Please review and confirm shifts to create" %}:
+        {% translate "Please review and confirm shifts to create" %}:
     </h2>
     <h2>
         {{ selected_date|date }}<br/>
@@ -35,14 +35,14 @@
         {% endfor %}
 
 
-        {% trans "no workplace" as no_workplace %}
-        {% trans "apply" as apply_trans %}
-        {% trans "volunteers" as num_trans %}
-        {% trans "task" as task_trans %}
-        {% trans "workplace" as workplace_trans %}
-        {% trans "starting time" as starting_trans %}
-        {% trans "ending time" as ending_trans %}
-        {% trans "members only" as members_only_trans %}
+        {% translate "no workplace" as no_workplace %}
+        {% translate "apply" as apply_trans %}
+        {% translate "volunteers" as num_trans %}
+        {% translate "task" as task_trans %}
+        {% translate "workplace" as workplace_trans %}
+        {% translate "starting time" as starting_trans %}
+        {% translate "ending time" as ending_trans %}
+        {% translate "members only" as members_only_trans %}
 
         {% regroup combined_shifts by task as shifts_by_task %}
 
@@ -114,9 +114,9 @@
         </table>
         </div>
         <div class="submit-row">
-            <input type="submit" value="{% trans "Apply" %}"
+            <input type="submit" value="{% translate "Apply" %}"
                    class="default" name="confirm">
-            <input type="submit" value="{% trans "Apply and select new date" %}"
+            <input type="submit" value="{% translate "Apply and select new date" %}"
                    class="default" name="confirm_and_repeat">
         </div>
     </form>

--- a/scheduletemplates/templates/admin/scheduletemplates/scheduletemplate/scheduletemplate_submit_line.html
+++ b/scheduletemplates/templates/admin/scheduletemplates/scheduletemplate/scheduletemplate_submit_line.html
@@ -1,10 +1,10 @@
 {% load i18n %}
 <div class="submit-row">
-{% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save" {{ onclick_attrib }}/> <input type="submit" value="{% trans 'Save and apply template' %}" class="default" name="_save_and_apply" {{ onclick_attrib }}/>{% endif %}
-{% if show_delete_link %}<p class="deletelink-box"><a href="delete/" class="deletelink">{% trans "Delete" %}</a></p>{% endif %}
-{% if show_save_as_new %}<input type="submit" value="{% trans 'Save as new' %}" name="_saveasnew" {{ onclick_attrib }}/>{%endif%}
-{% if show_save_and_add_another %}<input type="submit" value="{% trans 'Save and add another' %}" name="_addanother" {{ onclick_attrib }} />{% endif %}
-{% if show_save_and_continue %}<input type="submit" value="{% trans 'Save and continue editing' %}" name="_continue" {{ onclick_attrib }}/>{% endif %}
+{% if show_save %}<input type="submit" value="{% translate 'Save' %}" class="default" name="_save" {{ onclick_attrib }}/> <input type="submit" value="{% translate 'Save and apply template' %}" class="default" name="_save_and_apply" {{ onclick_attrib }}/>{% endif %}
+{% if show_delete_link %}<p class="deletelink-box"><a href="delete/" class="deletelink">{% translate "Delete" %}</a></p>{% endif %}
+{% if show_save_as_new %}<input type="submit" value="{% translate 'Save as new' %}" name="_saveasnew" {{ onclick_attrib }}/>{%endif%}
+{% if show_save_and_add_another %}<input type="submit" value="{% translate 'Save and add another' %}" name="_addanother" {{ onclick_attrib }} />{% endif %}
+{% if show_save_and_continue %}<input type="submit" value="{% translate 'Save and continue editing' %}" name="_continue" {{ onclick_attrib }}/>{% endif %}
 
 
 

--- a/scheduletemplates/templates/admin/scheduletemplates/shifttemplate/shift_template_inline.html
+++ b/scheduletemplates/templates/admin/scheduletemplates/shifttemplate/shift_template_inline.html
@@ -14,7 +14,7 @@
          </th>
        {% endif %}
      {% endfor %}
-     {% if inline_admin_formset.formset.can_delete %}<th>{% trans "Delete?" %}</th>{% endif %}
+     {% if inline_admin_formset.formset.can_delete %}<th>{% translate "Delete?" %}</th>{% endif %}
      </tr></thead>
 
      <tbody>
@@ -28,9 +28,9 @@
           {% if inline_admin_form.original or inline_admin_form.show_url %}<p>
           {% if inline_admin_form.original %}
 
-          {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}<a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="inlinechangelink">{% trans "Change" %}</a>{% endif %}
+          {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}<a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="inlinechangelink">{% translate "Change" %}</a>{% endif %}
           {% endif %}
-          {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% trans "View on site" %}</a>{% endif %}
+          {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
             </p>{% endif %}
           {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
           {{ inline_admin_form.fk_field.field }}
@@ -77,8 +77,8 @@
   $("#{{ inline_admin_formset.formset.prefix }}-group .tabular.inline-related tbody tr").tabularFormset({
     prefix: "{{ inline_admin_formset.formset.prefix }}",
     adminStaticPrefix: '{% static "admin/" %}',
-    addText: "{% blocktrans with inline_admin_formset.opts.verbose_name|capfirst as verbose_name %}Add another {{ verbose_name }}{% endblocktrans %}",
-    deleteText: "{% trans 'Remove' %}"
+    addText: "{% blocktranslate with inline_admin_formset.opts.verbose_name|capfirst as verbose_name %}Add another {{ verbose_name }}{% endblocktranslate %}",
+    deleteText: "{% translate 'Remove' %}"
   });
 })(django.jQuery);
 </script>

--- a/templates/partials/faq_link.html
+++ b/templates/partials/faq_link.html
@@ -1,2 +1,2 @@
 {% load i18n site %}
-<a href="/faq/">{% trans "FAQ" %}</a>
+<a href="/faq/">{% translate "FAQ" %}</a>

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -3,20 +3,20 @@
     <div class="container">
         <p class="text-muted text-center">
 
-            <a href="{% url 'home' %}">{% trans "Main page" %}</a> &bullet;
-            <a href="/impressum/">{% trans "Imprint" %}</a> &bullet;
-            <a href="/about/">{% trans "About" %}</a> &bullet;
-            <a href="/unterstuetzer/">{% trans "Supporter" %}</a> &bullet;
-            <a href="/presse/">{% trans "Press" %}</a> &bullet;
-            <a href="/kontakt/">{% trans "Contact" %}</a> &bullet;
+            <a href="{% url 'home' %}">{% translate "Main page" %}</a> &bullet;
+            <a href="/impressum/">{% translate "Imprint" %}</a> &bullet;
+            <a href="/about/">{% translate "About" %}</a> &bullet;
+            <a href="/unterstuetzer/">{% translate "Supporter" %}</a> &bullet;
+            <a href="/presse/">{% translate "Press" %}</a> &bullet;
+            <a href="/kontakt/">{% translate "Contact" %}</a> &bullet;
             {% include "partials/faq_link.html" %} &bullet;
             &copy; 2015 volunteer-planner.org &bullet;
             <a href="https://github.com/coders4help/volunteer_planner">GitHub</a> &bullet;
 
 
-            {% blocktrans trimmed with mailto_link='<a href="mailto:kontakt@volunteer-planner.org">kontakt@volunteer-planner.org</a>' %}
+            {% blocktranslate trimmed with mailto_link='<a href="mailto:kontakt@volunteer-planner.org">kontakt@volunteer-planner.org</a>' %}
                 Questions? Get in touch: {{ mailto_link }}
-            {% endblocktrans %}
+            {% endblocktranslate %}
 
         </p>
     </div>

--- a/templates/partials/management_tools.html
+++ b/templates/partials/management_tools.html
@@ -10,7 +10,7 @@
                        data-toggle="dropdown"
                        role="button" aria-haspopup="true"
                        aria-expanded="false">
-                        {% trans "Manage" %}
+                        {% translate "Manage" %}
 
                         {% if pending_approvals.total > 0 %}
                             <span class="badge blue-batches fa fa-user-plus">{{ pending_approvals.total }}</span>
@@ -25,7 +25,7 @@
                             <li class="dropdown-header">{{ facility.name }}</li>
                             <li>
                                 <a href="{% url "manage-members" facility.organization.slug facility.slug %}">
-                                    {% trans "Members" %}
+                                    {% translate "Members" %}
                                     {% if pending_approvals.facilities and pending_approvals.facilities|get:facility.id > 0 %}
                                         <span class="badge blue-batches fa fa-user-plus">
                                             {{ pending_approvals.facilities|get:facility.id }}

--- a/templates/partials/navigation_bar.html
+++ b/templates/partials/navigation_bar.html
@@ -8,7 +8,7 @@
 
         <div class="navbar-header">
             <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-                <span class="sr-only">{% trans "Toggle navigation" %}</span>
+                <span class="sr-only">{% translate "Toggle navigation" %}</span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
@@ -43,24 +43,24 @@
                     <ul class="dropdown-menu">
                         <li>
                             <a href="{% url 'account_detail' %}">
-                                {% trans "Account" %}
+                                {% translate "Account" %}
                             </a>
                         </li>
                         <li>
                             <a href="{% url 'shift_list_active' %}">
-                                {% trans "My work shifts" %}
+                                {% translate "My work shifts" %}
                             </a>
                         </li>
 
                         <li><!-- FIXME: remove static e-mail address -->
-                            <a href="mailto:kontakt@volunteer-planner.org">{% trans "Help" %}</a>
+                            <a href="mailto:kontakt@volunteer-planner.org">{% translate "Help" %}</a>
                         </li>
 
-                        <li><a href="{% url 'auth_logout' %}">{% trans "Logout" %}</a></li>
+                        <li><a href="{% url 'auth_logout' %}">{% translate "Logout" %}</a></li>
 
                         {% if user.is_staff or user.is_superuser %}
                             <li role="separator" class="divider"></li>
-                            <li><a href="{% url 'admin:index' %}">{% trans "Admin" %}</a></li>
+                            <li><a href="{% url 'admin:index' %}">{% translate "Admin" %}</a></li>
                         {% endif %}
                     </ul>
 

--- a/templates/partials/region_selection.html
+++ b/templates/partials/region_selection.html
@@ -15,7 +15,7 @@
                     {{ last_breadcrump.name }}
                 {% endwith %}
             {% else %}
-                {% trans "Regions" %}
+                {% translate "Regions" %}
             {% endif %}
             <span class="caret"></span>
         </a>

--- a/templates/registration/activate.html
+++ b/templates/registration/activate.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% block title %}
     {% if account %}
-        {% trans "Activation complete" %}
+        {% translate "Activation complete" %}
     {% else %}
-        {% trans "Activation problem" %}
+        {% translate "Activation problem" %}
     {% endif %}
 {% endblock %}
 
@@ -12,20 +12,20 @@
     {% if account %}
 
         {% url 'auth_login' as auth_login_url %}
-        {% trans "login" as login_link_title context "login link title in registration confirmation success text 'You may now %(login_link)s'" %}
+        {% translate "login" as login_link_title context "login link title in registration confirmation success text 'You may now %(login_link)s'" %}
 
-        {% blocktrans trimmed with login_link='<a href="'|add:auth_login_url|add:'">'|add:login_link_title|add:'</a>'|safe %}
+        {% blocktranslate trimmed with login_link='<a href="'|add:auth_login_url|add:'">'|add:login_link_title|add:'</a>'|safe %}
             Thanks {{ account }}, activation complete! You may now
             {{ login_link }} using the username and password you set at
             registration.
-        {% endblocktrans %}
+        {% endblocktranslate %}
 
     {% else %}
 
-        {% blocktrans trimmed %}
+        {% blocktranslate trimmed %}
             Oops &ndash; Either you activated your account already, or the
             activation key is invalid or has expired.
-        {% endblocktrans %}
+        {% endblocktranslate %}
 
     {% endif %}
 

--- a/templates/registration/activation_complete.html
+++ b/templates/registration/activation_complete.html
@@ -1,15 +1,15 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% block title %} {% trans "Activation successful!" %}{% endblock %}
+{% block title %} {% translate "Activation successful!" %}{% endblock %}
 {% block content %}
     {% url 'auth_login' as auth_login_url %}
 
     <div class="col-md-12">
         <h3>
-            {% trans "Thank you for signing up." context "Activation successful page" %}
+            {% translate "Thank you for signing up." context "Activation successful page" %}
             <br/>
             <a href="{{ auth_login_url }}">
-                {% trans "You can login here." context "Login link text on activation success page" %}
+                {% translate "You can login here." context "Login link text on activation success page" %}
             </a>
         </h3>
     </div>

--- a/templates/registration/activation_email.html
+++ b/templates/registration/activation_email.html
@@ -1,5 +1,5 @@
 {% load i18n %}{% url 'registration_activate' activation_key as activation_key_url %}
-{% blocktrans with site_domain=site.domain %}
+{% blocktranslate with site_domain=site.domain %}
 Hello {{ user }},
 
 thank you very much that you want to help! Just one more step and you'll be ready to start volunteering!
@@ -13,4 +13,4 @@ This link will expire in {{ expiration_days }} days.
 Yours,
 
 the volunteer-planner.org team
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/templates/registration/activation_email.txt
+++ b/templates/registration/activation_email.txt
@@ -1,5 +1,5 @@
 {% load i18n %}{% url 'registration_activate' activation_key as activation_key_url %}
-{% blocktrans with site_domain=site.domain %}
+{% blocktranslate with site_domain=site.domain %}
 Hello {{ user }},
 
 thank you very much that you want to help! Just one more step and you'll be ready to start volunteering!
@@ -13,4 +13,4 @@ This link will expire in {{ expiration_days }} days.
 Yours,
 
 the volunteer-planner.org team
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/templates/registration/activation_email_subject.txt
+++ b/templates/registration/activation_email_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% trans "Your volunteer-planner.org registration" %}
+{% load i18n %}{% translate "Your volunteer-planner.org registration" %}

--- a/templates/registration/admin_approve_complete_email.html
+++ b/templates/registration/admin_approve_complete_email.html
@@ -3,13 +3,13 @@
 <html lang="en">
 
 <head>
-    <title>{{ site.name }} {% trans "admin approval" %}</title>
+    <title>{{ site.name }} {% translate "admin approval" %}</title>
 </head>
 
 <body>
 <p>
     {% url 'auth_login' as login_url %}
-    {% blocktrans %}Your account is now approved. You can <a href="https://{{ site.domain }}{{ login_url }}">login now</a>.{% endblocktrans %}
+    {% blocktranslate %}Your account is now approved. You can <a href="https://{{ site.domain }}{{ login_url }}">login now</a>.{% endblocktranslate %}
 </p>
 </body>
 

--- a/templates/registration/admin_approve_complete_email.txt
+++ b/templates/registration/admin_approve_complete_email.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% blocktrans %}Your account is now approved. You can log in using the following link{% endblocktrans %}
+{% blocktranslate %}Your account is now approved. You can log in using the following link{% endblocktranslate %}
 http://{{site.domain}}{% url 'auth_login' %}
 
 {% comment %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,13 +1,13 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% block title %}{% trans "Login" %}{% endblock %}
+{% block title %}{% translate "Login" %}{% endblock %}
 {% block content %}
     {% url 'auth_password_reset' as auth_password_reset_url %}
     {% url 'registration_register' as registration_url %}
     <div class="col-md-4 form-container">
         <h1 class="text-right">{{ site.name }}</h1>
 
-        <h2 class="text-right">{% trans "Login" %}</h2>
+        <h2 class="text-right">{% translate "Login" %}</h2>
     </div>
     <div class="col-md-3 form-container border-left">
         {% for error in form.non_field_errors %}
@@ -28,7 +28,7 @@
                 {% translate "Email address" as email_trans %}
                 {% translate "Username" as username_trans %}
                 <input class="form-control"
-                       placeholder="{% blocktrans %}{{ email_trans }} / {{ username_trans }}{% endblocktrans %}"
+                       placeholder="{% blocktranslate %}{{ email_trans }} / {{ username_trans }}{% endblocktranslate %}"
                        name="username" autofocus>
             </div>
             <div class="form-group">
@@ -38,7 +38,7 @@
                     </div>
                 {% endfor %}
                 <input type="password" class="form-control"
-                       placeholder="{% trans "Password" %}" name="password">
+                       placeholder="{% translate "Password" %}" name="password">
             </div>
 
             <input type="submit" class="btn btn-primary align-left" value="login"/>
@@ -48,11 +48,11 @@
                 <div class="col-md-12">
                     <p>
                         <a href="{% url 'auth_password_reset' %}">
-                            {% trans "Forgot your password?" %}
+                            {% translate "Forgot your password?" %}
                         </a>
                         <br>
                         <a href="{% url 'registration_register' %}">
-                            {% trans "Help and sign-up" %}
+                            {% translate "Help and sign-up" %}
                         </a>
                     </p>
                 </div>

--- a/templates/registration/password_change_done.html
+++ b/templates/registration/password_change_done.html
@@ -1,9 +1,9 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% block title %}{% trans "Password changed" %}{% endblock %}
+{% block title %}{% translate "Password changed" %}{% endblock %}
 
 {% block registration_content %}
   <h2>
-    {% trans "Password successfully changed!" %}
+    {% translate "Password successfully changed!" %}
   </h2>
 {% endblock %}

--- a/templates/registration/password_change_form.html
+++ b/templates/registration/password_change_form.html
@@ -1,17 +1,17 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% block title %}{% trans "Change Password" %}{% endblock %}
+{% block title %}{% translate "Change Password" %}{% endblock %}
 
 {% block registration_content %}
-    <h2>{% trans "Change Password" %}</h2>
+    <h2>{% translate "Change Password" %}</h2>
 
     <form method='post' action=''>
         {% csrf_token %}
         <div class="form-group form-container">
-            <label for="exampleInputEmail1">{% trans "Email address" %}</label>
+            <label for="exampleInputEmail1">{% translate "Email address" %}</label>
             <input type="email" class="form-control" id="exampleInputEmail1"
-                placeholder="{% trans "Email address" %}">
+                placeholder="{% translate "Email address" %}">
         </div>
-        <input type='submit' class="btn btn-primary align-left" value="{% trans "Change password" %}"/>
+        <input type='submit' class="btn btn-primary align-left" value="{% translate "Change password" %}"/>
     </form>
 {% endblock %}

--- a/templates/registration/password_reset_complete.html
+++ b/templates/registration/password_reset_complete.html
@@ -1,14 +1,14 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% block title %}{% trans "Password reset complete" %}{% endblock %}
+{% block title %}{% translate "Password reset complete" %}{% endblock %}
 
 {% block registration_content %}
 
     <h2>
-        {% trans "log in" context "login link title reset password complete page" as login_link_text %}
+        {% translate "log in" context "login link title reset password complete page" as login_link_text %}
         {% url 'auth_login' as auth_login_url %}
-        {% blocktrans trimmed context "reset password complete page" with login_link='<a href="'|add:auth_login_url|add:'">'|add:login_link_text|add:'</a>'|safe %}
+        {% blocktranslate trimmed context "reset password complete page" with login_link='<a href="'|add:auth_login_url|add:'">'|add:login_link_text|add:'</a>'|safe %}
             Your password has been reset! You may now {{ login_link }} again.
-        {% endblocktrans %}
+        {% endblocktranslate %}
     </h2>
 {% endblock %}

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -1,15 +1,15 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% block title %}{% trans "Enter new password"  %}{% endblock %}
+{% block title %}{% translate "Enter new password"  %}{% endblock %}
 
 {% block registration_content %}
-    <h2>{% trans "Enter your new password below to reset your password" %}</h2>
+    <h2>{% translate "Enter your new password below to reset your password" %}</h2>
 
     <form method="post" action="">
         {% csrf_token %}
         <table>
             {{ form.as_table }}
         </table>
-        <input type="submit" class="btn btn-primary align-left" value="{% trans "Change password" %}"/>
+        <input type="submit" class="btn btn-primary align-left" value="{% translate "Change password" %}"/>
     </form>
 {% endblock %}

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -1,8 +1,8 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% block title %}{% trans "Password reset" %}{% endblock %}
+{% block title %}{% translate "Password reset" %}{% endblock %}
 
 {% block registration_content %}
-    <h2>{% trans "We sent you an email with a link to reset your password." %}</h2>
-    <p>{% trans "Please check your email and click the link to continue." %}</p>
+    <h2>{% translate "We sent you an email with a link to reset your password." %}</h2>
+    <p>{% translate "Please check your email and click the link to continue." %}</p>
 {% endblock %}

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,18 +1,18 @@
 {% load i18n %}"Greetings" {%  if user.get_full_name %}{%  else %}{% endif %},
 
-{%  blocktrans %}You are receiving this email because you (or someone pretending to be you)
+{% blocktranslate %}You are receiving this email because you (or someone pretending to be you)
 requested that your password be reset on the {{ domain }} site.  If you do not
 wish to reset your password, please ignore this message.
 
 To reset your password, please click the following link, or copy and paste it
-into your web browser:{% endblocktrans %}
+into your web browser:{% endblocktranslate %}
 
 {{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uid token %}
 
-{%  blocktrans with username=user.username %}
+{% blocktranslate with username=user.username %}
 Your username, in case you've forgotten: {{ username }}
 
 Best regards,
 {{ site_name }} Management
-{% endblocktrans %}
+{% endblocktranslate %}
 {% url 'registration_register' %}

--- a/templates/registration/password_reset_form.html
+++ b/templates/registration/password_reset_form.html
@@ -1,18 +1,18 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% block title %}{% trans "Reset password" %}{% endblock %}
+{% block title %}{% translate "Reset password" %}{% endblock %}
 
 {% block registration_content %}
-    <h2>{% trans "Forgot your password?" %}</h2>
-    <p>{% trans "No Problem! We'll send you instructions on how to reset your password." %}</p>
+    <h2>{% translate "Forgot your password?" %}</h2>
+    <p>{% translate "No Problem! We'll send you instructions on how to reset your password." %}</p>
 
     <form method='post' action='' style="margin-top:30px;">
         {% csrf_token %}
         <div class="form-group">
-            <label for="exampleInputEmail1">{% trans "Email address" %}</label>
+            <label for="exampleInputEmail1">{% translate "Email address" %}</label>
             <input type="email" class="form-control" id="exampleInputEmail1"
-                placeholder="{% trans "Email address" %}" name="email">
+                placeholder="{% translate "Email address" %}" name="email">
         </div>
-        <input type='submit' class="btn btn-primary align-left" value="{% trans "Reset password" %}" />
+        <input type='submit' class="btn btn-primary align-left" value="{% translate "Reset password" %}" />
     </form>
 {% endblock %}

--- a/templates/registration/registration_complete.html
+++ b/templates/registration/registration_complete.html
@@ -1,20 +1,20 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% block title %} {% trans "Activation email sent" %}{% endblock %}
+{% block title %} {% translate "Activation email sent" %}{% endblock %}
 {% block content %}
     <div class="col-md-12">
         <h2>
-            {% blocktrans trimmed %}
+            {% blocktranslate trimmed %}
                 An activation mail will be sent to you email address.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h2>
 
         <h3>
-            {% blocktrans trimmed %}
+            {% blocktranslate trimmed %}
                 Please confirm registration with the link in the email. If you
                 haven't received it in 10 minutes, look for it in your spam
                 folder.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </h3>
     </div>
 {% endblock %}

--- a/templates/registration/registration_form.html
+++ b/templates/registration/registration_form.html
@@ -1,13 +1,13 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% block title %}{% trans "Register for an account" %}{% endblock %}
+{% block title %}{% translate "Register for an account" %}{% endblock %}
 {% block content %}
-<h1 class="align-left">{% trans "You can create a new user account here. If you already have a user account click on LOGIN in the upper right corner." %} </h1>
+<h1 class="align-left">{% translate "You can create a new user account here. If you already have a user account click on LOGIN in the upper right corner." %} </h1>
 <br>
     <div class="col-md-1"></div>
 <div class="col-md-3 form-container ">
     <h1 class="align-right">{{ site.name }}</h1>
-    <h2 class="align-right">{% trans "Create a new account" %}</h2>
+    <h2 class="align-right">{% translate "Create a new account" %}</h2>
 </div>
 
 <div class="col-md-3 border-left form-container">
@@ -22,10 +22,10 @@
                 {% endfor %}
             <input type="email"
                    class="form-control"
-                   placeholder="{% trans "Email" %}"
+                   placeholder="{% translate "Email" %}"
                    name="email"
                    value="{{ form.cleaned_data.email|default:form.email.value|default:"" }}">
-             <p class="help-block">{% trans "Volunteer-Planner and shelters will send you emails concerning your shifts." %}</p>
+             <p class="help-block">{% translate "Volunteer-Planner and shelters will send you emails concerning your shifts." %}</p>
         </div>
 
         <div class="form-group {% if form.username.errors %}has-error{% endif %}">
@@ -37,10 +37,10 @@
                 {% endfor %}
             <input class="form-control"
                    id="Username"
-                   placeholder="{% trans "Username" %}"
+                   placeholder="{% translate "Username" %}"
                    name="username"
                    value="{{ form.cleaned_data.username|default:form.username.value|default:"" }}">
-            <p class="help-block">{% trans "Your username will be visible to other users. Don't use spaces or special characters." %}</p>
+            <p class="help-block">{% translate "Your username will be visible to other users. Don't use spaces or special characters." %}</p>
         </div>
 
         <div class="form-group {% if form.password1.errors %}has-error{% endif %}">
@@ -53,7 +53,7 @@
             </label>
             <input type="password"
                    class="form-control"
-                   placeholder="{% trans "Password" %}"
+                   placeholder="{% translate "Password" %}"
                    name="password1"
                    value="{{ form.cleaned_data.password1 }}">
         </div>
@@ -68,7 +68,7 @@
             </label>
             <input type="password"
                    class="form-control"
-                   placeholder="{% trans "Repeat password" %}"
+                   placeholder="{% translate "Repeat password" %}"
                    id="password2"
                    name="password2"
                    value="{{ form.cleaned_data.password2 }}">
@@ -80,18 +80,18 @@
                     id="accept_privacy_policy"
                     name="accept_privacy_policy">
             <label {% if form.accept_privacy_policy.errors %}style="color:red"{% endif %} for="accept_privacy_policy">
-                {% blocktrans %}I have read and agree to the <a href="/impressum/#datenschutz">Privacy Policy</a>.{% endblocktrans %}
+                {% blocktranslate %}I have read and agree to the <a href="/impressum/#datenschutz">Privacy Policy</a>.{% endblocktranslate %}
 
                 {% if form.accept_privacy_policy.errors %}
                     <div class="alert alert-danger">
-                        {% trans "This must be checked." %}
+                        {% translate "This must be checked." %}
                     </div>
                 {% endif %}
             </label>
 
         </div>
 
-        <button type="submit" class="btn btn-primary align-left">{% trans "Sign-up" %}</button>
+        <button type="submit" class="btn btn-primary align-left">{% translate "Sign-up" %}</button>
     </form>
 </div>
 


### PR DESCRIPTION
Changed in Django 3.1:
The `trans` tag was renamed to `translate` and `blocktrans` was renamed to `blocktranslate` and Raider is now known as Twix.

fixes #540