### PR TITLE
Use tz aware datetime in filter for DateTimeFields

### DIFF
--- a/scheduler/managers.py
+++ b/scheduler/managers.py
@@ -4,6 +4,7 @@ from datetime import datetime, time, timedelta
 
 from django.db import models
 from django.utils import timezone
+from django.utils.timezone import get_current_timezone
 
 from places import models as place_models
 from .settings import DEFAULT_SHIFT_CONFLICT_GRACE
@@ -19,8 +20,7 @@ class ShiftQuerySet(models.QuerySet):
         shiftdate. That means shifts that intersect with the day of
         shiftdate.
         """
-        # make sure, shiftdate is a date and not a datetime
-        shiftdate = datetime.combine(shiftdate, time.min).date()
+        shiftdate = datetime.combine(shiftdate, time(tzinfo=get_current_timezone()))
         return self.filter(
             ending_time__gte=shiftdate, starting_time__lt=shiftdate + timedelta(days=1)
         )


### PR DESCRIPTION
DateTimeFields are time zone aware fields, filtering using date objects seems to create naive datetime objects to compare to, which triggers a Django warning

"DateTimeField Shift.ending_time received a naive datetime (...) while time zone support is active."

Also, using time.min also is not tz aware. We need to construct a time(tzinfo=get_current_timezone()) which corresponds to 0:00:00.0 at the default time zone (settings.TIME_ZONE, ie. Europe/Berlin)