### PR TITLE
Flake8 config enhanced

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@ per-file-ignores =
    volunteer_planner/settings/*.py: F401, F403, F405,
 
 max-line-length = 88
+exclude = .*, __pycache__


### PR DESCRIPTION
Prevent flake8 from checking venv dir, git dir or pycache files.
This reduces amount of "files to check" - depending on individual setup
dramatically.
