### PR TITLE
Fix #575, broken icon in schedule template admin

### DIFF
--- a/scheduletemplates/templates/admin/scheduletemplates/shifttemplate/shift_template_inline.html
+++ b/scheduletemplates/templates/admin/scheduletemplates/shifttemplate/shift_template_inline.html
@@ -10,7 +10,7 @@
      {% for field in inline_admin_formset.fields %}
        {% if not field.widget.is_hidden %}
          <th{% if forloop.first %} colspan="2"{% endif %}{% if field.required %} class="required"{% endif %}>{{ field.label|capfirst }}
-         {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.gif" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
+         {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
          </th>
        {% endif %}
      {% endfor %}


### PR DESCRIPTION
Inline table head contains help icon with help text.
Old Django had GIF images, new version is SVG.
Fix image file path.
