### PR TITLE
Fixes #547: jQuery selector expected

### DIFF
--- a/scheduletemplates/templates/admin/scheduletemplates/shifttemplate/shift_template_inline.html
+++ b/scheduletemplates/templates/admin/scheduletemplates/shifttemplate/shift_template_inline.html
@@ -74,7 +74,7 @@
 <script type="text/javascript">
 
 (function($) {
-  $("#{{ inline_admin_formset.formset.prefix }}-group .tabular.inline-related tbody tr").tabularFormset({
+  $("#{{ inline_admin_formset.formset.prefix }}-group .tabular.inline-related tbody tr").tabularFormset("", {
     prefix: "{{ inline_admin_formset.formset.prefix }}",
     adminStaticPrefix: '{% static "admin/" %}',
     addText: "{% blocktranslate with inline_admin_formset.opts.verbose_name|capfirst as verbose_name %}Add another {{ verbose_name }}{% endblocktranslate %}",


### PR DESCRIPTION
Django jQuery tabularFormset function exptects first parameter to be a
selector and second parameter to be options.
Seems it used to be different once upon a time and selector was not
required, because function is called on already selected object.
But ... an empty selector is good enough, so we make jQuery happy, for
jQuery being able to make us happy.

Now there's an "Add" link again show in inline tabular form. :)
