### PR TITLE
Avoid unnecessary HTTP request for favicon

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,8 @@
 
     <title>{% block title %}{{ site.domain }}{% endblock %}</title>
 
+    <link rel="icon" type="image/x-icon" href="{% static "img/favicon.ico" %}">
+
     <!-- Bootstrap -->
     <link href="{% static "bootstrap/css/bootstrap.min.css" %}" rel="stylesheet">
     <link href="{% static "bootstrap/css/bootstrap-theme.min.css" %}" rel="stylesheet">


### PR DESCRIPTION
Not explicitly stating favicon location ends up in "browser searching
for it" by probing several URLs.
Some are responded with HTTP-301 (adding trailing slash), only for
eventually ending up in HTTP-404.
This reduces performance (although most probably not recognizable),
increases load (although most probably currently not recognizable),
clutters logs with 301 and 404 and has not a single positive aspect.
