### PR TITLE
Add sentry integration

### DIFF
--- a/requirements/postgres.txt
+++ b/requirements/postgres.txt
@@ -1,3 +1,5 @@
 -r base.txt
 
 psycopg2==2.9.3
+
+sentry-sdk==1.5.8

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,5 @@
 -r base.txt
 
 MySQL-python==1.2.5
+
+sentry-sdk==1.5.8

--- a/volunteer_planner/settings/production.py
+++ b/volunteer_planner/settings/production.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from .base import *  # noqa: F401
+from .sentry import *  # noqa: F401
 
 DEBUG = os.environ.get("BETA", False)
 

--- a/volunteer_planner/settings/sentry.py
+++ b/volunteer_planner/settings/sentry.py
@@ -1,0 +1,42 @@
+"""
+Imports and initializes sentry for usage within this Django instance.
+
+For successful initialization 'sentry-sdk' needs to be installed and some
+environment variables need to be present/set:
+- SENTRY_DSN: sentry data source name (https://docs.sentry.io/product/sentry-basics/dsn-explainer/)  # noqa: E501
+              mandatory, without no initialization will be successfully finished.
+- SENTRY_ENVIRON: string, used as 'environment' tag value
+                  default: 'production'
+- SENTRY_TRACE_RATE: float, (0..1), probability a transaction is performance monitored
+                     default: 0.0
+- SENTRY_SEND_PII: bool, (https://docs.sentry.io/platforms/python/configuration/options/#send-default-pii)  # noqa: 501
+                   default: False
+"""
+import logging
+import os
+
+from distutils.util import strtobool
+
+logger = logging.getLogger(__name__)
+
+try:
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+    from sentry_sdk.integrations.logging import LoggingIntegration
+
+    sentry_sdk.init(
+        dsn=os.environ["SENTRY_DSN"],
+        environment=os.environ.get("SENTRY_ENVIRON", "production"),
+        integrations=[
+            DjangoIntegration(),
+            LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
+        ],
+        traces_sample_rate=float(os.environ.get("SENTRY_TRACE_RATE", "0.0")),
+        # TODO think - really, I'm serious! - about some good 'traces_sampler'
+        #  implementation and replace 'traces_sample_rate'
+        send_default_pii=strtobool(os.environ.get("SENTRY_SEND_PII", "False")),
+    )
+except (ModuleNotFoundError, ImportError):
+    logger.warning("sentry not installed - skipping", exc_info=True)
+except (KeyError, NameError, ValueError):
+    logger.debug("sentry not initialized", exc_info=True)


### PR DESCRIPTION
sentry-sdk will be installed if using requirements files.
If sentry-sdk is available at runtime and a sentry DSN is configured,
using environment variables, sentry will be actively used with Django
integration.
