### PR TITLE
Introduce git commit template

### DIFF
--- a/.git-commit-template
+++ b/.git-commit-template
@@ -1,0 +1,30 @@
+# Title: Summary, imperative, start upper case, don't end with a period
+# No more than 50 chars. #### 50 chars is here:  #
+
+# Remember blank line between title and body.
+
+# Body: Explain *what* and *why* (not *how*). Include task ID (Jira issue).
+# Wrap at 72 chars. ################################## which is here:  #
+
+
+# At the end: Include Co-authored-by for all contributors. 
+# Include at least one empty line before it. Format: 
+# Co-authored-by: name <user@users.noreply.github.com>
+#
+# How to Write a Git Commit Message:
+# https://chris.beams.io/posts/git-commit/
+#
+#
+# 1. Separate subject from body with a blank line
+# 2. Limit the subject line to 50 characters
+# 3. Capitalize the subject line
+# 4. Do not end the subject line with a period
+# 5. Use the imperative mood in the subject line
+# 6. Wrap the body at 72 characters
+# 7. Use the body to explain what and why vs. how
+#
+# Template reference:
+# https://gist.github.com/lisawolderiksen/a7b99d94c92c6671181611be1641c733
+#
+# To activate this template:
+# $ git config --local commit.template .git-commit-template


### PR DESCRIPTION
A git commit template file within this repository enables every
committing person to use the same template and - over time - create
similar styled commit messages.

To activate it's usage one has to tell git about it.
We don't want to overwrite user's commit template, but if you copy the
template outside this repository and want to use it - or something
similar - in general: feel free.

The command to use the template is:

git config --local commit.template .git-commit-template
