### PR TITLE
Integrate django-post-office

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,7 @@ django-compressor==3.1
 django-debug-toolbar==3.2.4
 django-extensions==3.1.5
 django-logentry-admin==1.1.0
+django-post-office==3.6.0
 django-registration-redux==2.10
 git+https://github.com/Doca/django-ajax.git#egg=djangoajax
 

--- a/volunteer_planner/settings/base.py
+++ b/volunteer_planner/settings/base.py
@@ -9,8 +9,6 @@ https://docs.djangoproject.com/en/dev/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/dev/ref/settings/
 """
-import os
-from datetime import timedelta
 
 from django.utils.translation import gettext_lazy as _
 

--- a/volunteer_planner/settings/base.py
+++ b/volunteer_planner/settings/base.py
@@ -14,6 +14,8 @@ from datetime import timedelta
 
 from django.utils.translation import gettext_lazy as _
 
+from .email import *  # noqa: F401
+
 DEBUG = False
 # PROJECT DIRECTORY AND GENERAL SETTINGS
 PROJECT_ROOT = os.path.abspath(os.path.join(__file__, "..", ".."))
@@ -46,6 +48,7 @@ THIRD_PARTY_APPS = (
     "django_ajax",
     "django_extensions",
     "logentry_admin",
+    "post_office",
 )
 
 LOCAL_APPS = (
@@ -143,7 +146,7 @@ LOGIN_URL = "/auth/login/"
 USE_TZ = True
 TIME_ZONE = "Europe/Berlin"
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = os.environ.get("LANGUAGE_CODE", "en-us")
 
 LANGUAGES = (
     ("uk", _("Ukrainian")),

--- a/volunteer_planner/settings/email.py
+++ b/volunteer_planner/settings/email.py
@@ -1,0 +1,93 @@
+import os
+from datetime import timedelta
+from distutils.util import strtobool
+
+from django.core.mail import DNS_NAME
+
+
+# The actual backend is defined in BACKENDS in POST_OFFICE.
+EMAIL_BACKEND = "post_office.EmailBackend"
+
+
+# Default email address to use for various automated correspondence from the site
+# manager(s). This doesn’t include error messages sent to ADMINS and MANAGERS; for that,
+# see SERVER_EMAIL.
+# Default: 'webmaster@localhost'
+if "FROM_EMAIL" in os.environ or "DJANGO_FROM_EMAIL" in os.environ:
+    DEFAULT_FROM_EMAIL = os.environ.get(
+        "DJANGO_FROM_EMAIL", os.environ.get("FROM_EMAIL", "hallo@volunteer-planner.org")
+    )
+
+
+# The email address that error messages come from, such as those sent to ADMINS and
+# MANAGERS.
+# Default: 'root@localhost'
+if "SERVER_EMAIL" in os.environ or "DJANGO_SERVER_EMAIL" in os.environ:
+    SERVER_EMAIL = os.environ.get(
+        "DJANGO_SERVER_EMAIL",
+        os.environ.get("SERVER_EMAIL", "admin@volunteer-planner.org"),
+    )
+
+
+# The host to use for sending email.
+# Default: "localhost"
+if "SMTP_HOST" in os.environ or "DJANGO_EMAIL_HOST" in os.environ:
+    EMAIL_HOST = os.environ.get("DJANGO_EMAIL_HOST", os.environ.get("SMTP_HOST"))
+
+
+# Port to use for the SMTP server defined in EMAIL_HOST.
+# Default: 25
+if "SMTP_PORT" in os.environ or "DJANGO_EMAIL_PORT" in os.environ:
+    EMAIL_PORT = int(os.environ.get("DJANGO_EMAIL_PORT", os.environ.get("SMTP_PORT")))
+
+
+# Username to use for the SMTP server defined in EMAIL_HOST. If empty, Django won’t
+# attempt authentication.
+# Default: "" (Empty string)
+if "SMTP_USER" in os.environ or "DJANGO_EMAIL_HOST_USER" in os.environ:
+    EMAIL_HOST_USER = os.environ.get(
+        "DJANGO_EMAIL_HOST_USER", os.environ.get("SMTP_USER")
+    )
+
+
+# Password to use for the SMTP server defined in EMAIL_HOST. This setting is used in
+# conjunction with EMAIL_HOST_USER when authenticating to the SMTP server. If either of
+# these settings is empty, Django won’t attempt authentication.
+# Default: "" (Empty string)
+if "SMTP_PASS" in os.environ or "DJANGO_EMAIL_HOST_PASSWORD" in os.environ:
+    EMAIL_HOST_PASSWORD = os.environ.get(
+        "DJANGO_EMAIL_HOST_PASSWORD", os.environ.get("SMTP_PASS")
+    )
+
+
+# Whether to use a TLS (secure) connection when talking to the SMTP server. This is
+# used for explicit TLS connections, generally on port 587. If you are experiencing
+# hanging connections, see the implicit TLS setting EMAIL_USE_SSL.
+# Default: False
+if "DJANGO_EMAIL_USE_TLS" in os.environ:
+    EMAIL_USE_TLS = strtobool(str(os.environ.get("DJANGO_EMAIL_USE_TLS")))
+
+
+# Settings for django-post-office async email backend.
+# see https://github.com/ui/django-post_office
+POST_OFFICE = {
+    "BACKENDS": {
+        "default": os.environ.get(
+            "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+        )
+    },
+    "BATCH_SIZE": int(os.environ.get("POST_OFFICE_BATCH_SIZE", 100)),
+    "CELERY_ENABLED": False,
+    "DEFAULT_PRIORITY": "medium",
+    "LOG_LEVEL": int(os.environ.get("POST_OFFICE_LOG_LEVEL", 2)),
+    "MAX_RETRIES": int(os.environ.get("POST_OFFICE_MAX_RETRIES", 0)),
+    "MESSAGE_ID_ENABLED": False,
+    "MESSAGE_ID_FQDN": DNS_NAME,
+    "OVERRIDE_RECIPIENTS": None,
+    "RETRY_INTERVAL": timedelta(
+        minutes=int(os.environ.get("POST_OFFICE_RETRY_INTERVAL", 15))
+    ),
+    "SENDING_ORDER": ["-priority"],
+    "TEMPLATE_ENGINE": "django",
+    "THREADS_PER_PROCESS": int(os.environ.get("POST_OFFICE_THREADS_PER_PROCESS", 5)),
+}

--- a/volunteer_planner/settings/local.py
+++ b/volunteer_planner/settings/local.py
@@ -69,23 +69,7 @@ LOGGING = {
     },
 }
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-EMAIL_HOST_USER = os.environ.get("EMAIL_ADDRESS", None)
-EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", None)
-
-if EMAIL_HOST_USER and EMAIL_HOST_PASSWORD:
-    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-    COMMUNICATION_SENDER_MAIL = "noreply@noreply.de"
-    DEFAULT_FROM_EMAIL = "cantzen@googlemail.com"
-    CONTACT_MAIL = os.environ["EMAIL_ADDRESS"]
-    SERVER_EMAIL = os.environ["EMAIL_ADDRESS"]
-
-    EMAIL_HOST = "smtp.gmail.com"
-    EMAIL_PORT = 587
-    EMAIL_USE_TLS = True
-
 SECRET_KEY = os.environ.get("SECRET_KEY", "local")
-LANGUAGE_CODE = os.environ.get("LANGUAGE_CODE", "de")
 
 # for testing on mobile devices in local networks it's necessary to overwrite
 # with a local ip

--- a/volunteer_planner/settings/production.py
+++ b/volunteer_planner/settings/production.py
@@ -7,7 +7,6 @@ DEBUG = os.environ.get("BETA", False)
 
 STATIC_ROOT = os.environ["STATIC_ROOT"]
 
-
 # Let this be done by frontend reverse proxy, if required!
 PREPEND_WWW = False
 
@@ -26,19 +25,14 @@ DATABASES = {
 ALLOWED_HOSTS = os.environ.get(
     "ALLOWED_HOSTS", "volunteer-planner.org,www.volunteer-planner.org"
 ).split(sep=",") + ["localhost"]
+
 SECRET_KEY = os.environ["SECRET_KEY"]
-EMAIL_BACKEND = os.environ.get(
-    "EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend"
+
+POST_OFFICE.update(
+    {
+        "BACKENDS": {"default": "django.core.mail.backends.smtp.EmailBackend"},
+    }
 )
-COMMUNICATION_SENDER_MAIL = os.environ.get("SENDER_EMAIL")
-DEFAULT_FROM_EMAIL = os.environ.get("FROM_EMAIL")
-CONTACT_MAIL = [os.environ.get("CONTACT_EMAIL")]
-SERVER_EMAIL = os.environ.get("SERVER_EMAIL")
-EMAIL_HOST = os.environ.get("SMTP_HOST", "localhost")
-EMAIL_PORT = int(os.environ.get("SMTP_PORT", 25))
-EMAIL_USER = os.environ.get("SMTP_USER")
-EMAIL_PASS = os.environ.get("SMTP_PASS")
-EMAIL_USE_TLS = False
 
 SESSION_COOKIE_AGE = 28 * 24 * 3600
 SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
Adds 3rd party lib [django-post-office](https://github.com/ui/django-post_office) for deferring sending emails to an async cron/worker job. 

Sending emails will now require a cron job executing the management command `send_queued_mail`. Additionaly, an occasional (daily) clean-up cron job might be desired to be run, executing the management command `cleanup_mails` (see https://github.com/ui/django-post_office#management-commands for details).

* all email related settings are moved to volunteer_planner/settings/email.py and most may be overridden via environment vars
* for reference, currently POST_OFFICE config contains library defaults
* prepared some env var renaming: Django email settings are prefixed with `DJANGO_` and renamed to the actual settings var names. Old var names will still be read as fallback. For example: the environment variable name for setting the Django setting EMAIL_HOST_USER will prefer `DJANGO_EMAIL_HOST_USER` over `SMTP_USER`, but will fall back to `SMTP_USER` for backwards compatibility.
* hard coded local email settings have been removed, use environment variables instead