### PR TITLE
Fix no longer working slack invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ There are some feature requests to be implemented in the future.
 The software currently needs a centralized administration of the shifts, but it is one of the main goals of the current
 development to empower organizations to schedule shifts for their facilities on their own.
 
-If you are interested to contribute, join the [developer Slack channel](https://join.slack.com/t/coders4help/shared_invite/zt-1520v8cef-DytzxhO~ubmTrX0CdVcpxQ) or create a feature or fix pull request directly.
+If you are interested to contribute, you're invited to send an 
+[email](mailto:kontakt@volunteer-planner.org?subject=Slack%20Invitation%20Request) 
+to join the developer Slack channel or create a feature or fix pull request directly.
 
 ## System context
 **User**: The volunteers and administrators just need a (modern) web browser to use the volunteer-planner application.


### PR DESCRIPTION
Slack invitation links are of a limited life time, so it's an email link
instead, for us to be able to invite interested people, without having
to update this file and the link within every 30 days.

Fixes #605
