### PR TITLE
Update docker configuration and README

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,11 +9,19 @@ DATABASE_USER=vp
 DATABASE_PW=volunteer_planner
 
 ALLOWED_HOSTS=localhost
-SECRET_KEY=<some random string>
 
-ADMIN_EMAIL=<an email address for the admin user>
-DJANGO_FROM_EMAIL=<an email address used as "sender">
-DJANGO_SERVER_EMAIL=<an email address used by the server>
+# for local development 'local' is OK, # but better, and for anything else strongly recommended,
+# is to use the output of `python3 -c "import secrets; print(secrets.token_urlsafe())"` as SECRET_KEY.
+# (credits: https://humberto.io/blog/tldr-generate-django-secret-key/)
+SECRET_KEY=
+
+# intentionally left blank.
+# in local context (i. e. docker-compose.yml) it's replaced with reasonable default but you can overwrite
+# using values you'd like to see when developing.
+# in non-local context it's supposed
+ADMIN_EMAIL=
+DJANGO_FROM_EMAIL=
+DJANGO_SERVER_EMAIL=
 
 DJANGO_EMAIL_BACKEND=post_office.EmailBackend
 POST_OFFICE_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ db.sqlite3
 .python_history
 .venv
 .python-version
+.ipython/
+static/
+docker-compose.override.yml

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -13,6 +13,16 @@ welcome solution suggestions and are even more excited, if we can see and follow
 
 ## Project setup for development
 
+TL&DR:
+
+    copy .env.template .env
+    docker compose build
+    docker compose up --no-start
+    docker compose run -T --rm django migrate
+    docker compose run -T --rm django set_default_site --name "Volunteer Planner (local)" --domain "localhost"
+    docker compose run -T --rm -e DJANGO_SUPERUSER_PASSWORD=admin django createsuperuser --username admin --email admin@localhost --no-input
+    docker compose run -T --rm django create_dummy_data 5 --flush True
+
 ### 1. Install docker
 
 #### 1.1 Install docker engine
@@ -29,15 +39,15 @@ In this readme we'll use `docker compose`. If you prefer version 1 (`docker-comp
 using instructions here, by substituting
 `docker compose` with `docker-compose`.
 
-### 2. Prepare environment
+### 2. Prepare the docker files and settings
 
 #### 2.1 Create `.env` file
 
-Copy the `.env.template` file as `.env` and edit all values between `<>` to match your environment.
+If you already have `.env` file, compare it to `.env.template` and add or remove new or old values.
 
-### 3. Prepare the docker files
+If you don't have `.env` yet, copy `.env.template` as `.env` and edit values to match your environment.
 
-#### 3.1 Build images
+#### 2.2 Build images
 
 Execute
 
@@ -48,7 +58,7 @@ docker compose build
 This is currently necessary, because sometimes docker compose build does not reflect depedency between django image and
 web image.
 
-#### 3.1 Initialize docker network, volumes and containers
+#### 2.3 Initialize docker network, volumes and containers
 
 Execute
 
@@ -56,7 +66,7 @@ Execute
 docker compose up --no-start
 ```
 
-#### 3.3 Initalize by running migrations to set up non-existing tables
+#### 2.4 Initalize by running migrations to set up non-existing tables
 
 Execute
 
@@ -64,8 +74,25 @@ Execute
 docker compose run -T --rm django migrate
 ```
 
-#### 3.4 Add a superuser
+#### 2.5 Change default site
 
+For absolute links in emails and other locations to be generated correctly, it's advisable, to modify default site.
+If you don't, there's no known "it doesn't work" situation, but at least if you register new accounts for testing,
+emails will contain "wrong" links you'd have to fix manually ('example.com' vs. 'localhost').
+
+```shell
+docker compose run -T --rm django set_default_site --name "Volunteer Planner (local)" --domain "localhost"
+```
+
+#### 2.6 Add a superuser
+
+Fast track:
+```shell
+docker compose run -T --rm -e DJANGO_SUPERUSER_PASSWORD=vpadmin django createsuperuser --username vpadmin --email admin@localhost --no-input
+```
+
+If you're not a fan of (temporarily) having your local, developement, admin password in environment variables, removed after the
+command finished:
 ```shell
 docker compose run -T --rm django createsuperuser --username admin --email admin@localhost --no-input
 docker compose run --rm changepassword admin
@@ -76,7 +103,7 @@ docker compose run --rm changepassword admin
 If you want to, feel free to change username `admin` to something you like better. Changing the e-mail address is
 possible too, although it should not make a difference.
 
-### 4. The server
+### 3. The server
 
 To start / run the server
 
@@ -90,7 +117,7 @@ with `CTRL-c`.
 URL is identical to the one of `manage.py runserver`. So please stop any possibly running `runserver` process, before
 using docker.
 
-#### 4.1 If you don't want containers block your terminal
+#### 3.1 If you don't want containers block your terminal
 
 Run
 
@@ -101,9 +128,9 @@ docker compose up -d
 instead. This backgrounds containers (`detaches`), e. g. for longer period of testing UI. If you change sources, file
 watch should notice it, as project directory is mounted into the running container.
 
-#### 5. Rebuilding
+### 4. Rebuilding
 
-Repeat steps from step 2. and 3.
+TL&DR: Repeat actions from step 2. and 3.
 
 To clean up everything and start from scratch:
 
@@ -134,9 +161,9 @@ docker compose run -T --rm django migrate
 
 at any time - still running containers are no problem and usually don't need to be stopped or retarted
 
-### 6. Anything else
+### 5. Anything else
 
-#### 6.1 Stop all running services
+#### 5.1 Stop all running services
 
 To stop all eventually running servics, please execute the command
 
@@ -144,7 +171,7 @@ To stop all eventually running servics, please execute the command
 docker compose stop
 ```
 
-#### 6.2 Modify configuration
+#### 5.2 Modify configuration
 
 Please don't adjust the configuration in `docker-compose.yml` to reflect your desired docker changes.
 
@@ -155,12 +182,12 @@ Those, unaware with `docker compose`: Override is meant literally. You don't hav
 Create a service entry for "about to be overriden" service(s). Set "about to be changed" values (e. g. `ports`).
 Leave everything as it is, this keeps you updated with probable changes in `docker-compose.yml`.
 
-#### 6.3 Create dummy data
+#### 5.3 Create dummy data
 
 If you want to create dummy data you can run:
 
 ```shell
-docker compose run --rm -T django create_dummy_data 5 --flush True
+docker compose run -T --rm django create_dummy_data 5 --flush True
 ```
 to get 5 days of dummy data and delete tables in advance.
 
@@ -168,6 +195,8 @@ The number (5 in the above example) creates 5 days dummy data count from today. 
 without `--flush True` it is NOT deleting data before putting new data in.
 
 ## Additional information
+
+(FIXME ... someone needs to verify the following information, as time passed and PyCharm ain't the same version anymore)
 
 ### Speeding up debugging
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,11 +52,11 @@ services:
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE-volunteer_planner.settings.local_postgres}
       DATABASE_ENGINE: ${DATABASE_ENGINE:-django.db.backends.postgresql}
       DATABASE_HOST: db
-      DATABASE_NAME: ${DATABASE_NAME}
-      DATABASE_USER: ${DATABASE_USER}
-      DATABASE_PW: ${DATABASE_PW}
+      DATABASE_NAME: ${DATABASE_NAME-volunteer_planner}
+      DATABASE_USER: ${DATABASE_USER-vp}
+      DATABASE_PW: ${DATABASE_PW-volunteer_planner}
       ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost}
-      SECRET_KEY: ${SECRET_KEY:?Please set djangos SECRET_KEY in .env or build environment}
+      SECRET_KEY: ${SECRET_KEY?Please set djangos SECRET_KEY in .env or container creation environment}
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@localhost}
       DJANGO_FROM_EMAIL: ${DJANGO_FROM_EMAIL:-admin@localhost}
       DJANGO_SERVER_EMAIL: ${DJANGO_SERVER_EMAIL:-admin@localhost}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -78,14 +78,14 @@ services:
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE-volunteer_planner.settings.production}
       DATABASE_ENGINE: ${DATABASE_ENGINE:-django.db.backends.postgresql}
       DATABASE_HOST: db
-      DATABASE_NAME: ${DATABASE_NAME}
-      DATABASE_USER: ${DATABASE_USER}
-      DATABASE_PW: ${DATABASE_PW}
+      DATABASE_NAME: ${DATABASE_NAME?Please set DATABASE_NAME in .env or container creation environment}
+      DATABASE_USER: ${DATABASE_USER?Please set DATABASE_USER in .env or container creation environment}
+      DATABASE_PW: ${DATABASE_PW?Please set DATABASE_PW in .env or container creation environment}
       ALLOWED_HOSTS: ${ALLOWED_HOSTS-localhost}
-      SECRET_KEY: ${SECRET_KEY:?Please set djangos SECRET_KEY in .env or build environment}
-      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@localhost}
-      DJANGO_FROM_EMAIL: ${DJANGO_FROM_EMAIL:-admin@localhost}
-      DJANGO_SERVER_EMAIL: ${DJANGO_SERVER_EMAIL:-admin@localhost}
+      SECRET_KEY: ${SECRET_KEY?Please set djangos SECRET_KEY in .env or container creation environment}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:?Please set djangos ADMIN_EMAIL in .env or container creation environment}
+      DJANGO_FROM_EMAIL: ${DJANGO_FROM_EMAIL:?Please set DJANGO_FROM_EMAIL in .env or container creation environment}
+      DJANGO_SERVER_EMAIL: ${DJANGO_SERVER_EMAIL:?Please set DJANGO_SERVER_EMAIL in .env or container creation environment}
       DJANGO_EMAIL_BACKEND: ${EMAIL_BACKEND:-post_office.EmailBackend}
       POST_OFFICE_EMAIL_BACKEND: ${POST_OFFICE_EMAIL_BACKEND:-django.core.mail.backends.smtp.EmailBackend}
       DJANGO_EMAIL_HOST: ${DJANGO_EMAIL_HOST:-localhost}


### PR DESCRIPTION
This partially reverts PR #629, because .env.template intentionally left
some values blank.
Providing some helpful text as value, e. g. for SECRET_KEY, makes
'docker compose' think, everything is OK, although it most probably is
not. Some comments, explaining the how, are preferred.

Empty database settings are replaced with reasonable defaults, for local
development.

Documentation updated, to reflect the changes.
A little reordering, renumbering, fixing headline level ('Rebuilding'),
and adding 'TL&DR'.