### PR TITLE
Add celery support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,8 @@
 *.yml
 .*ignore
 *.log
-
+.ipython/
+.venv/
 **/*.pyc
+docker-compose.override.yml
+static/

--- a/.env.template
+++ b/.env.template
@@ -27,3 +27,6 @@ DJANGO_EMAIL_BACKEND=post_office.EmailBackend
 POST_OFFICE_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 DJANGO_EMAIL_HOST=mail
 DJANGO_EMAIL_PORT=587
+
+REDIS_HOST=redis
+CELERY_BEAT_SCHEDULER=django_celery_beat.schedulers:DatabaseScheduler

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,21 +24,18 @@ ADD ./requirements ${VP_BASE_DIR}/requirements
 RUN apk update && \
     apk add --virtual .build-deps \
         gcc \
-        jpeg-dev \
         musl-dev \
-        postgresql-dev \
         python3-dev \
-        zlib-dev \
+        libffi-dev \
         && \
     apk add \
         gettext \
         gettext-lang \
-        jpeg \
         jq \
         git \
         postgresql \
-        libffi-dev \
         py3-pip \
+        py3-wheel \
         uwsgi \
         uwsgi-cache \
         uwsgi-http \
@@ -49,8 +46,8 @@ RUN apk update && \
     apk del --purge .build-deps && \
     /bin/rm -rf /var/cache/apk/* /root/.cache
 
-ADD django-entrypoint.sh /
-RUN chmod 0755 /django-entrypoint.sh
+ADD django-entrypoint.sh celery-entrypoint.sh /
+RUN chmod 0755 /django-entrypoint.sh /celery-entrypoint.sh
 
 USER ${VP_USER}
 ADD --chown=${VP_USER}:${VP_USER} ./ ${VP_BASE_DIR}

--- a/celery-entrypoint.sh
+++ b/celery-entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+kill_by_pidfile() {
+    pidfile="${1}"
+
+    if [ -z "${pidfile}" ]
+    then
+        return
+    fi
+
+    if [ -f "${pidfile}" ]
+    then
+        pid="$(cat "${pidfile}")"
+        kill -TERM "${pid}"
+        rm "${pidfile}"
+    fi
+}
+
+shutdown() {
+    echo "Stopping celery beat" >&2
+    kill_by_pidfile /run/vp/celery-beat.pid
+
+    echo "Stopping celery worker" >&2
+    kill_by_pidfile /run/vp/celery-worker.pid
+}
+
+for sig in HUP INT QUIT FPE SEGV TERM USR1 USR2
+do
+    trap "shutdown ${sig}" "${sig}"
+done
+
+# cleanup old PID files
+shutdown HUP
+
+echo "Starting celery beat" >&2
+python3 -m celery \
+    --app worker \
+    beat \
+        --loglevel INFO \
+        --pidfile /run/vp/celery-beat.pid \
+        &
+
+echo "Starting celery worker" >&2
+python3 -m celery \
+    --app worker \
+    worker \
+        --loglevel INFO \
+        --concurrency 2 \
+        --events \
+        --statedb /run/vp/celery-worker \
+        --pidfile /run/vp/celery-worker.pid \
+        &
+
+wait
+
+echo "End of celery work ... CU next time" >&2
+exit 0

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -6,27 +6,28 @@ _exit=0
 shutdown() {
     echo "Got signal ${*}" >&2
     _exit=1
+
     if [ 0 -ne ${pid} ]
     then
         kill "-${1:-INT}" ${pid}
-	case "${1:-INT}" in
-	"HUP"|"FPE"|"SEGV"|"USR1"|"USR2")
-	    echo "Non terminal signal received." >&2
-	    _exit=0
-	    ;;
-	*)
-	    echo "Waiting for child process ${pid} to exit." >&2
-	    wait ${pid}
-	    echo "Child exited. Bye." >&2
-	    exit 0
-	    ;;
-	esac
+        case "${1:-INT}" in
+        "HUP"|"FPE"|"SEGV"|"USR1"|"USR2")
+            echo "Non terminal signal received." >&2
+            _exit=0
+            ;;
+        *)
+            echo "Waiting for child process ${pid} to exit." >&2
+            wait ${pid}
+            echo "Child exited. Bye." >&2
+            exit 0
+            ;;
+	    esac
     else
-	echo "No specific child PID known. Terminating all." >&2
-	killall -INT
-	echo "Waiting for all children to exit." >&2
-	wait
-	exit 1
+        echo "No specific child PID known. Terminating all." >&2
+        killall -INT
+        echo "Waiting for all children to exit." >&2
+        wait
+        exit 1
     fi
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,16 @@ x-logging: &default-logging
     max-size: 10m
     max-file: 3
 
+x-django-env: &default-django-environment
+  DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE-volunteer_planner.settings.local_postgres}
+  DATABASE_ENGINE: ${DATABASE_ENGINE:-django.db.backends.postgresql}
+  DATABASE_HOST: db
+  DATABASE_NAME: ${DATABASE_NAME-volunteer_planner}
+  DATABASE_USER: ${DATABASE_USER-vp}
+  DATABASE_PW: ${DATABASE_PW-volunteer_planner}
+  REDIS_HOST: ${REDIS_HOST:-redis}
+
+
 services:
   db:
     image: vp_pg:local
@@ -25,6 +35,7 @@ services:
     hostname: db
     logging: *default-logging
     stop_grace_period: 30s
+
 
   django:
     image: vp_django:local
@@ -45,16 +56,11 @@ services:
     hostname: django
     links:
       - db
+      - redis
     logging: *default-logging
     stop_grace_period: 10s
-
     environment:
-      DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE-volunteer_planner.settings.local_postgres}
-      DATABASE_ENGINE: ${DATABASE_ENGINE:-django.db.backends.postgresql}
-      DATABASE_HOST: db
-      DATABASE_NAME: ${DATABASE_NAME-volunteer_planner}
-      DATABASE_USER: ${DATABASE_USER-vp}
-      DATABASE_PW: ${DATABASE_PW-volunteer_planner}
+      <<: *default-django-environment
       ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost}
       SECRET_KEY: ${SECRET_KEY?Please set djangos SECRET_KEY in .env or container creation environment}
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@localhost}
@@ -63,6 +69,28 @@ services:
       DJANGO_EMAIL_BACKEND: ${DJANGO_EMAIL_BACKEND:-django.core.mail.backends.console.EmailBackend}
       DJANGO_EMAIL_HOST:
       DJANGO_EMAIL_PORT:
+
+
+  redis:
+    image: redis:6-alpine
+    networks:
+      <<: *default-network
+    logging: *default-logging
+
+
+  celery:
+    image: vp_django:local
+    entrypoint:
+      - /celery-entrypoint.sh
+    links:
+      - redis
+    networks:
+      <<: *default-network
+    logging: *default-logging
+
+    environment:
+      <<: *default-django-environment
+      CELERY_BEAT_SCHEDULER:
 
 volumes:
   data_volume_pg:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,6 +21,16 @@ x-healthcheck: &default-healthcheck
   retries: 2
   start_period: 10s
 
+x-django-env: &default-django-environment
+      DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE-volunteer_planner.settings.production}
+      DATABASE_ENGINE: ${DATABASE_ENGINE:-django.db.backends.postgresql}
+      DATABASE_HOST: db
+      DATABASE_NAME: ${DATABASE_NAME?Please set DATABASE_NAME in .env or container creation environment}
+      DATABASE_USER: ${DATABASE_USER?Please set DATABASE_USER in .env or container creation environment}
+      DATABASE_PW: ${DATABASE_PW?Please set DATABASE_PW in .env or container creation environment}
+      REDIS_HOST: ${REDIS_HOST:-redis}
+
+
 services:
   db:
     image: vp_pg:${STAGE:-prod}
@@ -65,6 +75,7 @@ services:
     hostname: django
     links:
       - db
+      - redis
     stop_grace_period: 10s
     deploy:
       restart_policy:
@@ -75,12 +86,7 @@ services:
         reservations:
           memory: 1G
     environment:
-      DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE-volunteer_planner.settings.production}
-      DATABASE_ENGINE: ${DATABASE_ENGINE:-django.db.backends.postgresql}
-      DATABASE_HOST: db
-      DATABASE_NAME: ${DATABASE_NAME?Please set DATABASE_NAME in .env or container creation environment}
-      DATABASE_USER: ${DATABASE_USER?Please set DATABASE_USER in .env or container creation environment}
-      DATABASE_PW: ${DATABASE_PW?Please set DATABASE_PW in .env or container creation environment}
+      <<: *default-django-environment
       ALLOWED_HOSTS: ${ALLOWED_HOSTS-localhost}
       SECRET_KEY: ${SECRET_KEY?Please set djangos SECRET_KEY in .env or container creation environment}
       ADMIN_EMAIL: ${ADMIN_EMAIL:?Please set djangos ADMIN_EMAIL in .env or container creation environment}
@@ -154,6 +160,27 @@ services:
     healthcheck:
       <<: *default-healthcheck
       test: ["CMD-SHELL", "postfix status 2>/dev/null"]
+
+
+  redis:
+    image: redis:6-alpine
+    networks:
+      <<: *default-network
+    logging: *default-logging
+
+
+  celery:
+    image: vp_django:local
+    entrypoint:
+      - /celery-entrypoint.sh
+    links:
+      - redis
+    networks:
+      <<: *default-network
+    logging: *default-logging
+    environment:
+      <<: *default-django-environment
+      CELERY_BEAT_SCHEDULER:
 
 
 volumes:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,8 +7,13 @@ django-logentry-admin==1.1.0
 django-post-office==3.6.0
 bleach<=4.1.0
 django-registration-redux==2.10
-git+https://github.com/Doca/django-ajax.git#egg=djangoajax
+git+https://github.com/Doca/django-ajax.git@a38e813cd576142aad2bf3cc8883a3af8f3140fb#egg=djangoajax
 
 python3-memcached==1.51
 
 ipython==8.2.0
+
+celery==5.2.6
+Redis==4.2.2
+django-celery-results==2.3.0
+git+https://github.com/celery/django-celery-beat.git@10123d357567ae31f241f89d98561220887799ae#egg=django-celery-beat

--- a/volunteer_planner/settings/base.py
+++ b/volunteer_planner/settings/base.py
@@ -47,6 +47,8 @@ THIRD_PARTY_APPS = (
     "django_extensions",
     "logentry_admin",
     "post_office",
+    "django_celery_results",
+    "django_celery_beat",
 )
 
 LOCAL_APPS = (
@@ -177,3 +179,14 @@ FACILITY_MANAGER_GROUPNAME = "Facility Manager"
 ORGANIZATION_MANAGER_GROUPNAME = "Organization Manager"
 
 DEFAULT_SHIFT_CONFLICT_GRACE = timedelta(hours=1)
+
+CELERY_BROKER_URL = f"redis://{os.environ.get('REDIS_HOST', 'localhost')}/"
+CELERY_RESULT_BACKEND = "django-db"
+CELERY_BEAT_SCHEDULER = os.environ.get(
+    "CELERY_BEAT_SCHEDULER", "django_celery_beat.schedulers:DatabaseScheduler"
+)
+# TODO
+# Hopefully, with 2.3.0 django-celery-beat will be TZ aware and working, but now
+# it's TzAwareCrontab uses pytz and does not handle ZoneInfo well
+# (https://github.com/celery/django-celery-beat/issues/518)
+DJANGO_CELERY_BEAT_TZ_AWARE = False

--- a/volunteer_planner/settings/email.py
+++ b/volunteer_planner/settings/email.py
@@ -84,7 +84,7 @@ POST_OFFICE = {
         )
     },
     "BATCH_SIZE": int(os.environ.get("POST_OFFICE_BATCH_SIZE", 100)),
-    "CELERY_ENABLED": False,
+    "CELERY_ENABLED": True,
     "DEFAULT_PRIORITY": "medium",
     "LOG_LEVEL": int(os.environ.get("POST_OFFICE_LOG_LEVEL", 2)),
     "MAX_RETRIES": int(os.environ.get("POST_OFFICE_MAX_RETRIES", 0)),

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/worker/celery.py
+++ b/worker/celery.py
@@ -1,0 +1,9 @@
+import os
+
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "volunteer_planner.settings.local")
+
+app = Celery()
+app.config_from_object("django.conf:settings", namespace="CELERY", force=True)
+app.autodiscover_tasks()


### PR DESCRIPTION
This changeset introduces celery infrastructure.
It uses Redis as broker.
It's motivating purpose is to schedule and send email messages asynchronously without necessity to run cron jobs. Especially in docker environment, cronjobs are kind of "infrastructure break".

Additional usage will be registration profile cleanup, session cleanup, etc.

Major change is change to requirements: celery, Redis and auxiliary packages are now required.
Additionally POST_OFFICE is set up for "CELERY ENABLED".

A celery worker app auto discovers tasks, provided by django apps.

With django-celery-beat, configured to use database as scheduler backend, management of recurring tasks can be done in django admin backend, i. e. self contained.

Set up is complemented by appropriate docker configuration with separate entrypoint script for new, dedicated celery container.