### PR TITLE
Fix error on template creation

### DIFF
--- a/scheduletemplates/admin.py
+++ b/scheduletemplates/admin.py
@@ -55,7 +55,7 @@ class ShiftTemplateForm(forms.ModelForm):
     def clean(self):
         """Validation of shift data, to prevent non-sense values to be entered"""
         schedule_template = self.cleaned_data.get("schedule_template")
-        if schedule_template:
+        if schedule_template and hasattr(schedule_template, "facility"):
             facility = schedule_template.facility
 
             task = self.cleaned_data.get("task")


### PR DESCRIPTION
When adding new scheduletemplate, not selecting facility yet but already
adding shifttemplate and saving an HTTP 500 is produced.
Form validation of inline form tried to validate against
scheduletemplate facility, which is not yet set.

This fix updates check, to check for existing facility value or skip
validation of inline form values.